### PR TITLE
Added primary and secondary refs for logs

### DIFF
--- a/meshsync/logstream.go
+++ b/meshsync/logstream.go
@@ -83,8 +83,10 @@ func (h *Handler) streamLogs(id string, req model.LogRequest, cfg config.Listene
 			ObjectType: broker.LogStreamObject,
 			EventType:  broker.Add,
 			Object: &model.LogObject{
-				ID:   req.ID,
-				Data: message,
+				ID:        req.ID,
+				Data:      message,
+				Primary:   req.Name,
+				Secondary: req.Container,
 			},
 		})
 		if err != nil {

--- a/pkg/model/log.go
+++ b/pkg/model/log.go
@@ -3,6 +3,12 @@ package model
 type LogObject struct {
 	ID   string `json:"id,omitempty"`
 	Data string `json:"data,omitempty"`
+
+	// Name of Pod, Svc, Deply getting logs for
+	Primary string `json:"primary,omitempty"`
+
+	// Specific detail about the log like Container or Pod Name
+	Secondary string `json:"secondary,omitempty"`
 }
 
 type LogRequest struct {


### PR DESCRIPTION
Signed-off-by: dhruv0000 <patel.4@iitj.ac.in>

**Description**
MeshSync will now pass the pod and container name, along with the log data to the NATS client.

This PR fixes [#100 [meshery-extensions]](https://github.com/layer5labs/meshery-extensions/issues/100)

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
