### PR TITLE
Fix: Send Possibly Stale Object on Broken WatchConn to Keep Meshery in Sync

### DIFF
--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -40,7 +40,7 @@ func (c *ResourceWatcher) startWatching(s cache.SharedIndexInformer) {
 		DeleteFunc: func(obj interface{}) {
 			// the obj can only be of two types, Unstructured or DeletedFinalStateUnknown.
 			// DeletedFinalStateUnknown means that the object that we receive may be `stale`
-			// becuase of the way informer behaves
+			// because of the way informer behaves
 
 			// refer 'https://pkg.go.dev/k8s.io/client-go/tools/cache#ResourceEventHandler.OnDelete'
 


### PR DESCRIPTION
**Description**

Currently, when the informer(_reflector_ component to be specific) performs _re-listing_ because of a broken watch connection, Meshery won't get some delete events because the `obj` will be of type `DeletedFinalStateUnknown` in those cases. 

This PR ensures that we don't lose a `Delete` event when the watch connection established by the informer breaks for some reason, by sending a _possibly stale_ object rather than not sending anything at all.

**Notes for Reviewers**

This _**may be**_ the reason for #90 and probably related to #100 although I highly doubt that because it is more likely that it's because of the way the clients are handling the events.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
