### PR TITLE
[Feat] Make use of the data stored in SharedInformer stores and refactor codebase

### DIFF
--- a/helpers/component_info.json
+++ b/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshsync",
   "type": "controller",
-  "next_error_code": 1014
+  "next_error_code": 1015
 }

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -84,10 +84,5 @@ var (
 			ConnectionName: "meshsync-request-stream",
 			SubscribeTo:    "meshery.meshsync.request",
 		},
-		InformerStore: {
-			Name:           InformerStore,
-			ConnectionName: "meshsync-informer-store",
-			SubscribeTo:    "meshery.meshsync.store",
-		},
 	}
 )

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -84,5 +84,10 @@ var (
 			ConnectionName: "meshsync-request-stream",
 			SubscribeTo:    "meshery.meshsync.request",
 		},
+		InformerStore: {
+			Name:           InformerStore,
+			ConnectionName: "meshsync-informer-store",
+			SubscribeTo:    "meshery.meshsync.store",
+		},
 	}
 )

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -14,6 +14,7 @@ const (
 	RequestStream = "request-stream"
 	LogStream     = "log-stream"
 	ExecShell     = "exec-shell"
+	InformerStore = "informer-store"
 )
 
 type PipelineConfigs []PipelineConfig

--- a/internal/pipeline/error.go
+++ b/internal/pipeline/error.go
@@ -8,6 +8,7 @@ const (
 	ErrListCode          = "1001"
 	ErrPublishCode       = "1002"
 	ErrDynamicClientCode = "1003"
+	ErrCacheSyncCode     = "1014"
 )
 
 func ErrDynamicClient(name string, err error) error {
@@ -20,4 +21,8 @@ func ErrList(name string, err error) error {
 
 func ErrPublish(name string, err error) error {
 	return errors.New(ErrPublishCode, errors.Alert, []string{"Error while publishing for: " + name, err.Error()}, []string{}, []string{}, []string{})
+}
+
+func ErrCacheSync(name string, err error) error {
+	return errors.New(ErrCacheSyncCode, errors.Alert, []string{"Error while syncing the informer store for: " + name, err.Error()}, []string{}, []string{}, []string{})
 }

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -20,12 +20,12 @@ type QueueEvent struct {
 	Config internalconfig.PipelineConfig
 }
 
-func (c *RegisterInformer) registerHandlers(s cache.SharedIndexInformer) {
+func (ri *RegisterInformer) registerHandlers(s cache.SharedIndexInformer) {
 
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			c.queue.Add(QueueEvent{Obj: obj.(*unstructured.Unstructured), EvType: broker.Add, Config: c.config})
-			c.log.Info("Added ADD event for:", obj.(*unstructured.Unstructured).GetName(), "to the queue")
+			ri.queue.Add(QueueEvent{Obj: obj.(*unstructured.Unstructured), EvType: broker.Add, Config: ri.config})
+			ri.log.Info("Added ADD event for: ", obj.(*unstructured.Unstructured).GetName(), "/", obj.(*unstructured.Unstructured).GetNamespace(), " to the queue")
 
 		},
 		UpdateFunc: func(oldObj, obj interface{}) {
@@ -37,10 +37,10 @@ func (c *RegisterInformer) registerHandlers(s cache.SharedIndexInformer) {
 			newRV, _ := strconv.ParseInt(oldObjCasted.GetResourceVersion(), 0, 64)
 
 			if oldRV < newRV {
-				c.queue.Add(QueueEvent{Obj: objCasted, EvType: broker.Update, Config: c.config})
-				c.log.Info("Added UPDATE event for:", obj.(*unstructured.Unstructured).GetName(), " to the queue")
+				ri.queue.Add(QueueEvent{Obj: objCasted, EvType: broker.Update, Config: ri.config})
+				ri.log.Info("Added UPDATE event for: ", obj.(*unstructured.Unstructured).GetName(), "/", obj.(*unstructured.Unstructured).GetNamespace(), " to the queue")
 			} else {
-				c.log.Debug(fmt.Sprintf(
+				ri.log.Debug(fmt.Sprintf(
 					"Skipping UPDATE event for: %s => [No changes detected]: %d %d",
 					objCasted.GetName(),
 					oldRV,
@@ -62,8 +62,8 @@ func (c *RegisterInformer) registerHandlers(s cache.SharedIndexInformer) {
 			if ok {
 				objCasted = possiblyStaleObj.Obj.(*unstructured.Unstructured)
 			}
-			c.queue.Add(QueueEvent{Obj: objCasted, EvType: broker.Delete, Config: c.config})
-			c.log.Info("Added DELETE event for:", objCasted.GetName(), " to the queue")
+			ri.queue.Add(QueueEvent{Obj: objCasted, EvType: broker.Delete, Config: ri.config})
+			ri.log.Info("Added DELETE event for: ", obj.(*unstructured.Unstructured).GetName(), "/", obj.(*unstructured.Unstructured).GetNamespace(), " to the queue")
 		},
 	}
 	s.AddEventHandler(handlers)

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -20,7 +20,7 @@ type QueueEvent struct {
 	Config internalconfig.PipelineConfig
 }
 
-func (c *ResourceWatcher) registerHandlers(s cache.SharedIndexInformer) {
+func (c *RegisterInformer) registerHandlers(s cache.SharedIndexInformer) {
 
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -15,6 +15,7 @@ import (
 
 // type of the events that will be added to the workqueue
 type QueueEvent struct {
+	// TODO: Change this to store only Key from the cache
 	Obj    *unstructured.Unstructured
 	EvType broker.EventType
 	Config internalconfig.PipelineConfig
@@ -94,7 +95,7 @@ func (pq *ProcessQueue) processQueueItem() bool {
 	var err error
 
 	if !ok {
-		err = fmt.Errorf("This type of event cannot be processed: %v", item)
+		err = fmt.Errorf("This type of QueueEvent cannot be processed: %v", item)
 		pq.log.Error(err)
 	}
 

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -3,30 +3,20 @@ package pipeline
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/layer5io/meshkit/broker"
 	internalconfig "github.com/layer5io/meshsync/internal/config"
 	"github.com/layer5io/meshsync/pkg/model"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 )
-
-// type of the events that will be added to the workqueue
-type QueueEvent struct {
-	// TODO: Change this to store only Key from the cache
-	Obj    *unstructured.Unstructured
-	EvType broker.EventType
-	Config internalconfig.PipelineConfig
-}
 
 func (ri *RegisterInformer) registerHandlers(s cache.SharedIndexInformer) {
 
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			ri.queue.Add(QueueEvent{Obj: obj.(*unstructured.Unstructured), EvType: broker.Add, Config: ri.config})
-			ri.log.Info("Added ADD event for: ", obj.(*unstructured.Unstructured).GetName(), "/", obj.(*unstructured.Unstructured).GetNamespace(), " to the queue")
+			ri.publishItem(obj.(*unstructured.Unstructured), broker.Add, ri.config)
+			ri.log.Info("Received ADD event for: ", obj.(*unstructured.Unstructured).GetName(), "/", obj.(*unstructured.Unstructured).GetNamespace(), " of kind: ", obj.(*unstructured.Unstructured).GroupVersionKind().Kind)
 
 		},
 		UpdateFunc: func(oldObj, obj interface{}) {
@@ -38,8 +28,8 @@ func (ri *RegisterInformer) registerHandlers(s cache.SharedIndexInformer) {
 			newRV, _ := strconv.ParseInt(oldObjCasted.GetResourceVersion(), 0, 64)
 
 			if oldRV < newRV {
-				ri.queue.Add(QueueEvent{Obj: objCasted, EvType: broker.Update, Config: ri.config})
-				ri.log.Info("Added UPDATE event for: ", obj.(*unstructured.Unstructured).GetName(), "/", obj.(*unstructured.Unstructured).GetNamespace(), " to the queue")
+				ri.publishItem(obj.(*unstructured.Unstructured), broker.Update, ri.config)
+				ri.log.Info("Received UPDATE event for: ", obj.(*unstructured.Unstructured).GetName(), "/", obj.(*unstructured.Unstructured).GetNamespace(), " of kind: ", obj.(*unstructured.Unstructured).GroupVersionKind().Kind)
 			} else {
 				ri.log.Debug(fmt.Sprintf(
 					"Skipping UPDATE event for: %s => [No changes detected]: %d %d",
@@ -63,80 +53,21 @@ func (ri *RegisterInformer) registerHandlers(s cache.SharedIndexInformer) {
 			if ok {
 				objCasted = possiblyStaleObj.Obj.(*unstructured.Unstructured)
 			}
-			ri.queue.Add(QueueEvent{Obj: objCasted, EvType: broker.Delete, Config: ri.config})
-			ri.log.Info("Added DELETE event for: ", obj.(*unstructured.Unstructured).GetName(), "/", obj.(*unstructured.Unstructured).GetNamespace(), " to the queue")
+			ri.publishItem(objCasted, broker.Delete, ri.config)
+			ri.log.Info("Received DELETE event for: ", obj.(*unstructured.Unstructured).GetName(), "/", obj.(*unstructured.Unstructured).GetNamespace(), " of kind: ", obj.(*unstructured.Unstructured).GroupVersionKind().Kind)
 		},
 	}
 	s.AddEventHandler(handlers)
 }
 
-func (pq *ProcessQueue) startProcessing() {
-
-	// workerqueue provides us the guarantee that an item
-	// will not be processed more than once concurrently
-	// TODO: Configure multiple workers to improve performance
-	go wait.Until(func() {
-		for pq.processQueueItem() {
-		}
-	}, 1*time.Second, pq.stopChan)
-
-}
-
-func (pq *ProcessQueue) processQueueItem() bool {
-	item, shutdown := pq.queue.Get()
-	if shutdown {
-		return false
-	}
-
-	defer pq.queue.Done(item) // to remove the item from the queue
-
-	informerEvent, ok := item.(QueueEvent)
-
-	var err error
-
-	if !ok {
-		err = fmt.Errorf("This type of QueueEvent cannot be processed: %v", item)
-		pq.log.Error(err)
-	}
-
-	switch informerEvent.EvType {
-	case broker.Add:
-		err = pq.publishItem(informerEvent.Obj, broker.Add, informerEvent.Config)
-	case broker.Update:
-		err = pq.publishItem(informerEvent.Obj, broker.Update, informerEvent.Config)
-	case broker.Delete:
-		err = pq.publishItem(informerEvent.Obj, broker.Delete, informerEvent.Config)
-	}
-
-	pq.handleError(err, item)
-
-	return true
-
-}
-
-func (pq *ProcessQueue) handleError(err error, key interface{}) {
-	if err == nil {
-		pq.queue.Forget(key) // removes the item from retries list
-		return
-	}
-	// retries for the given amount of time
-	// TODO: Get the number of retires from the caller
-	if pq.queue.NumRequeues(key) < 6 {
-		pq.queue.AddRateLimited(key)
-		return
-	}
-	pq.queue.Forget(key)
-	pq.log.Error(fmt.Errorf("Dropping item: %v out of queue as it could be processed even after several retries", key))
-}
-
-func (pq *ProcessQueue) publishItem(obj *unstructured.Unstructured, evtype broker.EventType, config internalconfig.PipelineConfig) error {
-	err := pq.brokerClient.Publish(config.PublishTo, &broker.Message{
+func (ri *RegisterInformer) publishItem(obj *unstructured.Unstructured, evtype broker.EventType, config internalconfig.PipelineConfig) error {
+	err := ri.broker.Publish(config.PublishTo, &broker.Message{
 		ObjectType: broker.MeshSync,
 		EventType:  evtype,
 		Object:     model.ParseList(*obj),
 	})
 	if err != nil {
-		pq.log.Error(ErrPublish(config.Name, err))
+		ri.log.Error(ErrPublish(config.Name, err))
 		return err
 	}
 

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -20,7 +20,7 @@ type QueueEvent struct {
 	Config internalconfig.PipelineConfig
 }
 
-func (c *ResourceWatcher) startWatching(s cache.SharedIndexInformer) {
+func (c *ResourceWatcher) registerHandlers(s cache.SharedIndexInformer) {
 
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -66,10 +66,7 @@ func (c *ResourceWatcher) startWatching(s cache.SharedIndexInformer) {
 			c.log.Info("Added DELETE event for:", objCasted.GetName(), " to the queue")
 		},
 	}
-
 	s.AddEventHandler(handlers)
-	s.Run(c.stopChan)
-
 }
 
 func (pq *ProcessQueue) startProcessing() {

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -3,11 +3,13 @@ package pipeline
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/layer5io/meshkit/broker"
 	internalconfig "github.com/layer5io/meshsync/internal/config"
 	"github.com/layer5io/meshsync/pkg/model"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -71,8 +73,14 @@ func (c *ResourceWatcher) startWatching(s cache.SharedIndexInformer) {
 }
 
 func (pq *ProcessQueue) startProcessing() {
-	for pq.processQueueItem() {
-	}
+
+	// workerqueue provides us the guarantee that an item
+	// will not be processed more than once concurrently
+	go wait.Until(func() {
+		for pq.processQueueItem() {
+		}
+	}, 1*time.Second, pq.stopChan)
+
 }
 
 func (pq *ProcessQueue) processQueueItem() bool {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -22,11 +22,6 @@ var (
 		Steps:      []pipeline.Step{},
 	}
 
-	QueueProcessingStage = &pipeline.Stage{
-		Name:       "QueueProcessing",
-		Concurrent: false,
-		Steps:      []pipeline.Step{},
-	}
 
 	StartInformersStage = &pipeline.Stage{
 		Name:       "StartInformers",

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -42,18 +42,19 @@ func New(log logger.Handler, informer dynamicinformer.DynamicSharedInformerFacto
 	gdstage := GlobalDiscoveryStage
 	configs := plConfigs[gdstage.Name]
 	for _, config := range configs {
-		gdstage.AddStep(newRegisterInformerStep(log, informer, config, queue)) // register the informers for different resources
+		gdstage.AddStep(newRegisterInformerStep(log, informer, config, queue)) // Register the informers for different resources
 	}
 
 	// Local discovery
 	ldstage := LocalDiscoveryStage
 	configs = plConfigs[ldstage.Name]
 	for _, config := range configs {
-		ldstage.AddStep(newRegisterInformerStep(log, informer, config, queue)) // register the informers for different resources
+		ldstage.AddStep(newRegisterInformerStep(log, informer, config, queue)) // Register the informers for different resources
 	}
 
+	// Start informers
 	strtInfmrs := StartInformersStage
-	strtInfmrs.AddStep(newStartInformersStep(stopChan, log, informer)) // Starts the registered informers
+	strtInfmrs.AddStep(newStartInformersStep(stopChan, log, informer)) // Start the registered informers
 
 	// Queue Processing
 	qprcss := QueueProcessingStage

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -42,14 +42,14 @@ func New(log logger.Handler, informer dynamicinformer.DynamicSharedInformerFacto
 	gdstage := GlobalDiscoveryStage
 	configs := plConfigs[gdstage.Name]
 	for _, config := range configs {
-		gdstage.AddStep(newRegisterInformerStep(log, informer, broker, config, stopChan, queue)) // register the informers for different resources
+		gdstage.AddStep(newRegisterInformerStep(log, informer, config, queue)) // register the informers for different resources
 	}
 
 	// Local discovery
 	ldstage := LocalDiscoveryStage
 	configs = plConfigs[ldstage.Name]
 	for _, config := range configs {
-		ldstage.AddStep(newRegisterInformerStep(log, informer, broker, config, stopChan, queue)) // register the informers for different resources
+		ldstage.AddStep(newRegisterInformerStep(log, informer, config, queue)) // register the informers for different resources
 	}
 
 	strtInfmrs := StartInformersStage

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -22,7 +22,6 @@ var (
 		Steps:      []pipeline.Step{},
 	}
 
-
 	StartInformersStage = &pipeline.Stage{
 		Name:       "StartInformers",
 		Concurrent: false,
@@ -31,7 +30,6 @@ var (
 )
 
 func New(log logger.Handler, informer dynamicinformer.DynamicSharedInformerFactory, broker broker.Handler, plConfigs map[string]internalconfig.PipelineConfigs, stopChan chan struct{}) *pipeline.Pipeline {
-
 	// Global discovery
 	gdstage := GlobalDiscoveryStage
 	configs := plConfigs[gdstage.Name]

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -48,7 +48,7 @@ func New(log logger.Handler, informer dynamicinformer.DynamicSharedInformerFacto
 
 	// Queue Processing
 	qprcss := QueueProcessingStage
-	qprcss.AddStep(newProcessQueueStep(log, queue, broker, informer)) // Processes the events in the queue
+	qprcss.AddStep(newProcessQueueStep(stopChan, log, queue, broker, informer)) // Processes the events in the queue
 
 	// Create Pipeline
 	clusterPipeline := pipeline.New(Name, 1000)

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -29,6 +29,7 @@ func newRegisterInformerStep(log logger.Handler, informer dynamicinformer.Dynami
 	}
 }
 
+// TODO: Find a way to respond when an informer has stopped for some reason unkown
 // Exec - step interface
 func (ri *RegisterInformer) Exec(request *pipeline.Request) *pipeline.Result {
 	gvr, _ := schema.ParseResourceArg(ri.config.Name)

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -28,7 +28,7 @@ func newRegisterInformerStep(log logger.Handler, informer dynamicinformer.Dynami
 	}
 }
 
-// TODO: Find a way to respond when an informer has stopped for some reason unkown
+// TODO: Find a way to respond when an informer has stopped for some reason unknown
 // Exec - step interface
 func (ri *RegisterInformer) Exec(request *pipeline.Request) *pipeline.Result {
 	gvr, _ := schema.ParseResourceArg(ri.config.Name)
@@ -49,8 +49,8 @@ func (ri *RegisterInformer) Exec(request *pipeline.Request) *pipeline.Result {
 }
 
 // Cancel - step interface
-func (c *RegisterInformer) Cancel() error {
-	c.Status("cancel step")
+func (ri *RegisterInformer) Cancel() error {
+	ri.Status("cancel step")
 	return nil
 }
 

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -11,29 +11,25 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-type ResourceWatcher struct {
+type RegisterInformer struct {
 	pipeline.StepContext
-	log          logger.Handler
-	informer     dynamicinformer.DynamicSharedInformerFactory
-	brokerClient broker.Handler
-	config       internalconfig.PipelineConfig
-	stopChan     chan struct{}
-	queue        workqueue.RateLimitingInterface
+	log      logger.Handler
+	informer dynamicinformer.DynamicSharedInformerFactory
+	config   internalconfig.PipelineConfig
+	queue    workqueue.RateLimitingInterface
 }
 
-func newRegisterInformerStep(log logger.Handler, informer dynamicinformer.DynamicSharedInformerFactory, bclient broker.Handler, config internalconfig.PipelineConfig, stopChan chan struct{}, queue workqueue.RateLimitingInterface) *ResourceWatcher {
-	return &ResourceWatcher{
-		log:          log,
-		informer:     informer,
-		brokerClient: bclient,
-		config:       config,
-		stopChan:     stopChan,
-		queue:        queue,
+func newRegisterInformerStep(log logger.Handler, informer dynamicinformer.DynamicSharedInformerFactory, config internalconfig.PipelineConfig, queue workqueue.RateLimitingInterface) *RegisterInformer {
+	return &RegisterInformer{
+		log:      log,
+		informer: informer,
+		config:   config,
+		queue:    queue,
 	}
 }
 
 // Exec - step interface
-func (c *ResourceWatcher) Exec(request *pipeline.Request) *pipeline.Result {
+func (c *RegisterInformer) Exec(request *pipeline.Request) *pipeline.Result {
 	gvr, _ := schema.ParseResourceArg(c.config.Name)
 	iclient := c.informer.ForResource(*gvr)
 	c.registerHandlers(iclient.Informer())
@@ -44,7 +40,7 @@ func (c *ResourceWatcher) Exec(request *pipeline.Request) *pipeline.Result {
 }
 
 // Cancel - step interface
-func (c *ResourceWatcher) Cancel() error {
+func (c *RegisterInformer) Cancel() error {
 	c.Status("cancel step")
 	return nil
 }
@@ -82,7 +78,7 @@ func (pq *ProcessQueue) Cancel() error {
 	return nil
 }
 
-// StartInformer Step
+// StartInformers Step
 
 type StartInformers struct {
 	pipeline.StepContext

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -56,14 +56,16 @@ type ProcessQueue struct {
 	pipeline.StepContext
 	queue        workqueue.RateLimitingInterface
 	brokerClient broker.Handler
+	stopChan     chan struct{}
 	log          logger.Handler
 }
 
-func newProcessQueueStep(log logger.Handler, queue workqueue.RateLimitingInterface, bclient broker.Handler, informer dynamicinformer.DynamicSharedInformerFactory) *ProcessQueue {
+func newProcessQueueStep(stopChan chan struct{}, log logger.Handler, queue workqueue.RateLimitingInterface, bclient broker.Handler, informer dynamicinformer.DynamicSharedInformerFactory) *ProcessQueue {
 	return &ProcessQueue{
 		log:          log,
 		brokerClient: bclient,
 		queue:        queue,
+		stopChan:     stopChan,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 		Username:       "",
 		Password:       "",
 		ReconnectWait:  2 * time.Second,
-		MaxReconnect:   5,
+		MaxReconnect:   60,
 	})
 	if err != nil {
 		log.Error(err)

--- a/meshsync/discovery.go
+++ b/meshsync/discovery.go
@@ -15,7 +15,7 @@ func (h *Handler) startDiscovery(pipelineCh chan struct{}) {
 	}
 
 	h.Log.Info("Pipeline started")
-	pl := pipeline.New(h.Log, h.informer, h.Broker, pipelineConfigs, pipelineCh, h.queue)
+	pl := pipeline.New(h.Log, h.informer, h.Broker, pipelineConfigs, pipelineCh)
 	result := pl.Run()
 	h.stores = result.Data.(map[string]cache.Store)
 	if result.Error != nil {

--- a/meshsync/discovery.go
+++ b/meshsync/discovery.go
@@ -3,7 +3,6 @@ package meshsync
 import (
 	"github.com/layer5io/meshsync/internal/config"
 	"github.com/layer5io/meshsync/internal/pipeline"
-	// "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
 )
 

--- a/meshsync/discovery.go
+++ b/meshsync/discovery.go
@@ -3,6 +3,8 @@ package meshsync
 import (
 	"github.com/layer5io/meshsync/internal/config"
 	"github.com/layer5io/meshsync/internal/pipeline"
+	// "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
 )
 
 func (h *Handler) startDiscovery(pipelineCh chan struct{}) {
@@ -15,6 +17,7 @@ func (h *Handler) startDiscovery(pipelineCh chan struct{}) {
 	h.Log.Info("Pipeline started")
 	pl := pipeline.New(h.Log, h.informer, h.Broker, pipelineConfigs, pipelineCh, h.queue)
 	result := pl.Run()
+	h.stores = result.Data.(map[string]cache.Store)
 	if result.Error != nil {
 		h.Log.Error(ErrNewPipeline(result.Error))
 	}

--- a/meshsync/discovery.go
+++ b/meshsync/discovery.go
@@ -13,7 +13,7 @@ func (h *Handler) startDiscovery(pipelineCh chan struct{}) {
 	}
 
 	h.Log.Info("Pipeline started")
-	pl := pipeline.New(h.Log, h.informer, h.Broker, pipelineConfigs, pipelineCh)
+	pl := pipeline.New(h.Log, h.informer, h.Broker, pipelineConfigs, pipelineCh, h.queue)
 	result := pl.Run()
 	if result.Error != nil {
 		h.Log.Error(ErrNewPipeline(result.Error))

--- a/meshsync/exec.go
+++ b/meshsync/exec.go
@@ -79,7 +79,7 @@ func (h *Handler) getActiveChannels() []*string {
 	return activeChannels
 }
 
-func (h *Handler) streamChannelPool() error {
+func (h *Handler) streamChannelPool() {
 	go func() {
 		for {
 			err := h.Broker.Publish("active_sessions.exec", &broker.Message{
@@ -93,8 +93,6 @@ func (h *Handler) streamChannelPool() error {
 			time.Sleep(10 * time.Second)
 		}
 	}()
-
-	return nil
 }
 
 func (h *Handler) streamSession(id string, req model.ExecRequest, cfg config.ListenerConfig) {

--- a/meshsync/handlers.go
+++ b/meshsync/handlers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/layer5io/meshkit/broker"
 	"github.com/layer5io/meshsync/internal/channels"
 	"github.com/layer5io/meshsync/internal/config"
+	// "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func (h *Handler) Run() {
@@ -55,6 +56,11 @@ func (h *Handler) ListenToRequests() {
 				h.Log.Error(err)
 				continue
 			}
+
+			// TODO: Have to add this to the broker types
+		case "informer-store":
+			h.Log.Info("Sending the current state of the informer store")
+
 		case broker.ReSyncDiscoveryEntity:
 			h.Log.Info("Resyncing")
 			h.channelPool[channels.ReSync].(channels.ReSyncChannel) <- struct{}{}

--- a/meshsync/handlers.go
+++ b/meshsync/handlers.go
@@ -113,7 +113,6 @@ func (h *Handler) ListenToRequests() {
 					h.Log.Error(err)
 					continue
 				}
-
 			}
 
 		case broker.ReSyncDiscoveryEntity:
@@ -146,7 +145,7 @@ func (h *Handler) listStoreObjects() []interface{} {
 }
 
 // TODO: move this to meshkit
-// given [1,2,3,4,5,6,7,5,4,4] and 3 as its arguements, it would
+// given [1,2,3,4,5,6,7,5,4,4] and 3 as its arguments, it would
 // return [[1,2,3], [4,5,6], [7,5,4], [4]]
 func splitIntoMultipleSlices(s []model.Object, maxItmsPerSlice int) []([]model.Object) {
 	result := make([]([]model.Object), 0)

--- a/meshsync/meshsync.go
+++ b/meshsync/meshsync.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 )
 
 // Handler contains all handlers, channels, clients, and other parameters for an adapter.
@@ -26,7 +25,6 @@ type Handler struct {
 	informer     dynamicinformer.DynamicSharedInformerFactory
 	staticClient *kubernetes.Clientset
 	channelPool  map[string]channels.GenericChannel
-	queue        workqueue.RateLimitingInterface
 	stores       map[string]cache.Store
 }
 
@@ -47,6 +45,5 @@ func New(config config.Handler, log logger.Handler, br broker.Handler, pool map[
 		restConfig:   kubeClient.RestConfig,
 		staticClient: kubeClient.KubeClient,
 		channelPool:  pool,
-		queue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 	}, nil
 }

--- a/meshsync/meshsync.go
+++ b/meshsync/meshsync.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -26,6 +27,7 @@ type Handler struct {
 	staticClient *kubernetes.Clientset
 	channelPool  map[string]channels.GenericChannel
 	queue        workqueue.RateLimitingInterface
+	stores       map[string]cache.Store
 }
 
 func New(config config.Handler, log logger.Handler, br broker.Handler, pool map[string]channels.GenericChannel) (*Handler, error) {

--- a/meshsync/meshsync.go
+++ b/meshsync/meshsync.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // Handler contains all handlers, channels, clients, and other parameters for an adapter.
@@ -24,6 +25,7 @@ type Handler struct {
 	informer     dynamicinformer.DynamicSharedInformerFactory
 	staticClient *kubernetes.Clientset
 	channelPool  map[string]channels.GenericChannel
+	queue        workqueue.RateLimitingInterface
 }
 
 func New(config config.Handler, log logger.Handler, br broker.Handler, pool map[string]channels.GenericChannel) (*Handler, error) {
@@ -43,5 +45,6 @@ func New(config config.Handler, log logger.Handler, br broker.Handler, pool map[
 		restConfig:   kubeClient.RestConfig,
 		staticClient: kubeClient.KubeClient,
 		channelPool:  pool,
+		queue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 	}, nil
 }


### PR DESCRIPTION
**Description**

This PR makes leverages the data that are in the `Stores` that `SharedInformers` maintain so that a client, such as Meshery Server does not have to ask MeshSync to resync every time it needs to replay the old events to arrive at the current state of the cluster. I have also refactored some parts of the codebase.


**Notes for Reviewers**

- There are some places where I have added TODO statements since they require changes to be done in MeshKit. Those will be addressed in a different PR.

- Error codes are yet to be created for the functionalities that has been introduced in this PR, which would be addressed in a different PR.



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
