### PR TITLE
Add env variable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ FROM gcr.io/distroless/base-debian10
 WORKDIR /
 ENV GODISTRO="debian"
 ENV GOARCH="amd64"
+ENV VERSION=$GIT_VERSION
 COPY --from=builder /build/meshery-meshsync .
 ENTRYPOINT ["/meshery-meshsync"]


### PR DESCRIPTION
Signed-off-by: MUzairS15 <muzair.shaikh810@gmail.com>

**Description**

This PR sets `version` as an environment variable in Dockerfile which is to be used by Meshery Server to get version of MeshSync.
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
