### PR TITLE
Fix failing state sync and remove extranous error log

### DIFF
--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -67,18 +67,18 @@ var (
 				PublishTo: "meshery.meshsync.core",
 			},
 			// Istio Resources
-			{
-				Name:      "virtualservices.v1beta1.networking.istio.io",
-				PublishTo: "meshery.meshsync.istio",
-			},
-			{
-				Name:      "gateways.v1beta1.networking.istio.io",
-				PublishTo: "meshery.meshsync.istio",
-			},
-			{
-				Name:      "destinationrules.v1beta1.networking.istio.io",
-				PublishTo: "meshery.meshsync.istio",
-			},
+			// {
+			// 	Name:      "virtualservices.v1beta1.networking.istio.io",
+			// 	PublishTo: "meshery.meshsync.istio",
+			// },
+			// {
+			// 	Name:      "gateways.v1beta1.networking.istio.io",
+			// 	PublishTo: "meshery.meshsync.istio",
+			// },
+			// {
+			// 	Name:      "destinationrules.v1beta1.networking.istio.io",
+			// 	PublishTo: "meshery.meshsync.istio",
+			// },
 		},
 	}
 

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -72,6 +72,7 @@ func newStartInformersStep(stopChan chan struct{}, log logger.Handler, informer 
 }
 
 func (si *StartInformers) Exec(request *pipeline.Request) *pipeline.Result {
+	si.informer.WaitForCacheSync(si.stopChan)
 	si.informer.Start(si.stopChan)
 	return &pipeline.Result{
 		Error: nil,


### PR DESCRIPTION
Signed-off-by: revolyssup <ashishjaitiwari15112000@gmail.com>

**Description**

This PR fixes #
1. The state was not being synced as WaitForCache was being called after the informer had already started. This PR calls WaitForCache only before starting the informer. NOTE: It is not related to resync.
2. Due to missing CRDs, creating informer for istio resources results in error. This PR removes those extra resources
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
