### PR TITLE
Add golangci-lint's cconfiguration

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -61,10 +61,3 @@ jobs:
         docker push ${{ secrets.IMAGE_NAME }}:stable-latest
         docker push ${{ secrets.IMAGE_NAME }}:stable-${GITHUB_REF/refs\/tags\//}
         docker push ${{ secrets.IMAGE_NAME }}:stable-${GITHUB_SHA::7}
-#     - name: Docker Hub Description
-#       if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
-#       uses: peter-evans/dockerhub-description@v2.0.0
-#       env:
-#         DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-#         DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-#         DOCKERHUB_REPOSITORY: ${{ secrets.IMAGE_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,47 +1,60 @@
-name: Meshsync
+name: Meshsync CI
+
 on:
   push:
-    # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-    # * Matches zero or more characters, but does not match the / character
-    # ** Matches zero or more of any character
-    branches:
-      - '**'
-    tags:
-      - 'v*'
+    branches: [ master ]
   pull_request:
-    branches:
-      - master
+    branches: [ master ]
 
 jobs:
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-22.04
+  golangci-lint:
+    strategy:
+      matrix:
+        platform: [ubuntu-22.04]
+        go-version: [1.21.x]
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out code
-        uses: actions/checkout@main
+        uses: actions/checkout@master
       - name: Setup go
         uses: actions/setup-go@main
         with:
-          check-latest: 'true'
-          go-version: '^1.21'
-      - name: Build check
-        run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build -o meshery-meshsync . 
+          go-version: ${{ matrix.go-version }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.52
-          args:  --exclude=G107 --timeout=10m ./...
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-          skip-build-cache: true
+          version: latest
+          args:  --timeout=5m
+  codecov:
+    needs: golangci-lint
+    name: Code coverage
+    if: github.repository == 'meshery/meshsync'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.x'
+      - name: Run unit tests
+        run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
+      - name: Upload coverage to Codecov
+        if: github.repository == 'meshery/meshsync'
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.txt
+          flags: unittests
+  build:
+    needs: [golangci-lint, codecov]
+    name: Build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.x'
+      - name: Build
+        run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 **errorutil_errors_export.json
 
 .vscode/
+cover.html

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,144 +1,62 @@
 linters-settings:
-  depguard:
-    list-type: blacklist
-    packages:
-      # logging is allowed only by logutils.Log, logrus
-      # is allowed to use only in logutils package
-      - github.com/sirupsen/logrus
-    packages-with-error-message:
-      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
-  dupl:
-    threshold: 100
-  exhaustive:
-    default-signifies-exhaustive: false
-  funlen:
-    lines: 100
-    statements: 50
   gci:
-    local-prefixes: github.com/golangci/golangci-lint
+    enabled: true
+    max-len: 120
+    line-length: 120
   goconst:
-    min-len: 2
-    min-occurrences: 2
+    enabled: true
   gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - wrapperFunc
-  gocyclo:
-    min-complexity: 15
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
-  golint:
-    min-confidence: 0
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: 
-          - argument
-          - case
-          - condition
-          - return
-  gosec:
-    settings:
-      exclude: -G204,-G107
+    enabled: true
+    disable:
+      - parallelize
+      - nesting
+      - hugeParam
+      - hugeStruct
+      - nestParam
+      - prealloc
   govet:
-    check-shadowing: false
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  lll:
-    line-length: 950
-  maligned:
-    suggest-new: true
-  misspell:
-    locale: US
-  nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    enabled: true
+    check-shadowing: true
+    tests: true
+  golint:
+    enabled: true
+    min-confidence: 0.8
+  unused:
+    enabled: true
+    check-exported: true
+    check-packages: true
+    check-generated: true
+    tests: true
+    allow-unused-type-export: true
+  cyclop:
+    enabled: true
+    average-strictness: 7
+  scopelint:
+    enabled: true
+    tests: true
 
+# Configuration for golangci-lint that is suitable for a Kubernetes operator project built with Golang
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  # https://golangci-lint.run/usage/linters/
-  disable-all: true
-  enable:
-    # TODO: consider continuously if more should be enabled.
-    # Can also be useful to run with more strict settings before commit locally, i.e. to test for TODOs (godox)
-    # - bodyclose
-    # - deadcode
-    - dogsled
-    # - dupl
-    - errcheck
-    # - exhaustive
-    # - funlen
-    # - goconst
-    # - gocritic
-    # - gocyclo
-    - gofmt
-    - goimports
-    # - golint
-    - gomodguard
-    - gosec
-    # - gomnd
-    # - goprintffuncname
-    - gosimple
+  enable-all: false
+  disable-all: false
+  linters:
+    - gci
+    - goconst
+    - gocritic
     - govet
-    - ineffassign
-    # - interfacer
-    - lll
-    - misspell
-    # - nakedret
-    # - nolintlint
-    # - rowserrcheck
-    # - scopelint
-    - staticcheck
-    # - structcheck
-    - stylecheck
-    - typecheck
-    # - unconvert
-    # - unparam
+    - golint
     - unused
-    # - varcheck
-    - whitespace
-    - asciicheck
-#    - gochecknoglobals
-#    - gocognit
-#    - godot
-#    - godox
-#    - goerr113
-#    - maligned
-#    - nestif
-#    - prealloc
-#    - testpackage
-#    - wsl
-
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
+    - cyclop
+    - scopelint
   exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
+    - testpackage
 
-    # https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
-
-    - linters:
-        - gofmt
-      text: "lf"
+run:
+  enable-cache: true
+  skip-dirs:
+    - vendor
+    - bundle
+    - config
+    - hack
+    - helpers
+    - img

--- a/Makefile
+++ b/Makefile
@@ -9,32 +9,24 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-.PHONY: go-checks
-go-checks: go-lint go-fmt go-mod-tidy
 
-.PHONY: go-vet
-go-vet:
-	go vet ./...
-
-.PHONY: go-lint
-go-lint:
-	$(GOBIN)/golangci-lint run ./...
-
-.PHONY: go-fmt
-go-fmt:
-	go fmt ./...
+# Test covergae
+.PHONY: coverage
+coverage:
+	go test -v ./... -coverprofile cover.out
+	go tool cover -html=cover.out -o cover.html
 
 .PHONY: go-mod-tidy
 go-mod-tidy:
 	./scripts/go-mod-tidy.sh
 
-.PHONY: go-test
-go-test:
-	./scripts/go-test.sh
-
 .PHONY: check
-check: error
+check:
 	$(GOBIN)/golangci-lint run ./...
+
+.PHONY: build
+build:
+	go build -o bin/meshsync main.go
 
 .PHONY: docker-check
 docker: check
@@ -53,9 +45,6 @@ run: check
 	go$(v) mod tidy; \
 	DEBUG=true GOPROXY=direct GOSUMDB=off go run main.go
 
-.PHONY: error
-error:
-	go run github.com/layer5io/meshkit/cmd/errorutil -d . analyze -i ./helpers -o ./helpers
 
  # runs a local instance of nats server in detached mode
 PHONY: nats

--- a/meshsync/discovery.go
+++ b/meshsync/discovery.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Layer5, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package meshsync
 
 import (

--- a/meshsync/handlers_test.go
+++ b/meshsync/handlers_test.go
@@ -1,0 +1,52 @@
+package meshsync
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/layer5io/meshsync/pkg/model"
+)
+
+// TestSplitIntoMultipleSlices tests the splitIntoMultipleSlices function
+// by providing different input test cases and comparing the output with the expected output.
+func TestSplitIntoMultipleSlices(t *testing.T) {
+	testCases := []struct {
+		name            string
+		input           []model.Object
+		maxItmsPerSlice int
+		expectedOutput  [][]model.Object
+	}{
+		{
+			name:            "test with 0 items",
+			input:           []model.Object{},
+			maxItmsPerSlice: 10,
+			expectedOutput:  [][]model.Object{},
+		},
+
+		{
+			name: "test with 1 item",
+			input: []model.Object{
+				{
+					Kind: "test",
+				},
+			},
+			maxItmsPerSlice: 10,
+			expectedOutput: [][]model.Object{
+				{
+					{
+						Kind: "test",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := splitIntoMultipleSlices(tc.input, tc.maxItmsPerSlice)
+			if !reflect.DeepEqual(output, tc.expectedOutput) {
+				t.Errorf("expected %v, but got %v", tc.expectedOutput, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**

This PR fixes #

**Notes for Reviewers**

* Update `.golangci.config`, make it as same as `meshery-operator`. It is really useful for check the potential issues of Kubernetes related project. We do not enable all checker or disable all. We should keep the configuration readable by maintainers.
*  This PR also fixed some of issues were checked by `golangci-lint` of the code.
* Add code `coverage` to the CI.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
