### PR TITLE
fix init and close of logs stream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/layer5io/meshery-operator v0.7.0
 	github.com/layer5io/meshkit v0.7.9
 	github.com/myntra/pipeline v0.0.0-20180618182531-2babf4864ce8
+	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/net v0.19.0
@@ -134,7 +135,6 @@ require (
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/internal/config/crd_config.go
+++ b/internal/config/crd_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/layer5io/meshery-operator/pkg/client"
 	"github.com/layer5io/meshkit/utils"
@@ -168,7 +169,7 @@ func PopulateConfigs(configMap corev1.ConfigMap) (*MeshsyncConfig, error) {
 func PatchCRVersion(config *rest.Config) error {
 	meshsyncClient, err := client.New(config)
 	if err != nil {
-		return err
+		return ErrInitConfig(fmt.Errorf("unable to update MeshSync configuration"))
 	}
 
 	patchedResource := map[string]interface{}{
@@ -178,11 +179,11 @@ func PatchCRVersion(config *rest.Config) error {
 	}
 	byt, err := utils.Marshal(patchedResource)
 	if err != nil {
-		return err
+		return ErrInitConfig(fmt.Errorf("unable to update MeshSync configuration"))
 	}
 	_, err = meshsyncClient.CoreV1Alpha1().MeshSyncs("meshery").Patch(context.TODO(), crName, types.MergePatchType, []byte(byt), metav1.PatchOptions{})
 	if err != nil {
-		return err
+		return ErrInitConfig(fmt.Errorf("unable to update MeshSync configuration"))
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/layer5io/meshsync/internal/channels"
 	"github.com/layer5io/meshsync/internal/config"
 	"github.com/layer5io/meshsync/meshsync"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -33,7 +34,8 @@ func main() {
 
 	// Initialize Logger instance
 	log, err := logger.New(serviceName, logger.Options{
-		Format: logger.SyslogLogFormat,
+		Format:   logger.SyslogLogFormat,
+		LogLevel: int(logrus.InfoLevel),
 	})
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
**Description**

The log stream once created was not getting closed causing issues when the user again tried to stream logs for the same pod.
The PR ensure the log stream is appropriately closed when 'stop' signal is received.
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
