### PR TITLE
Bump `meshsync` Go version to 1.23 in workflows, Dockerfile, and go.mod

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@main
       with:
-        go-version: '1.21'
+        go-version: '1.23'
         check-latest: 'true'
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build -o meshery-meshsync . 
   docker:
@@ -32,7 +32,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@main
       with:
-        go-version: '1.21'
+        go-version: '1.23'
         check-latest: 'true'
     - name: Docker login
       uses: docker/login-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-22.04]
-        go-version: [1.21.x]
+        go-version: [1.23.x]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out code
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21.x'
+          go-version: '1.23.x'
       - name: Run unit tests
         run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
@@ -55,6 +55,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21.x'
+          go-version: '1.23.x'
       - name: Build
         run: make build

--- a/.github/workflows/error-codes-updater.yml
+++ b/.github/workflows/error-codes-updater.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@main
         with:
-          go-version: ${{ secrets.GO_VERSION }}
+          go-version: '1.23'
 
       - name: Run utility
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.23 as builder
 ARG GIT_VERSION
 ARG GIT_COMMITSHA
 

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ replace (
 	vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
 )
 
-go 1.21
+go 1.23
 
-toolchain go1.21.1
+toolchain go1.23.4
 
 require (
 	github.com/buger/jsonparser v1.1.1


### PR DESCRIPTION
upgrading `meshsync`

fixes: meshery/meshery#12829