### PR TITLE
Update Dockerfile to use uppercase 'AS' for builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 ARG GIT_VERSION
 ARG GIT_COMMITSHA
 


### PR DESCRIPTION
Signed-off-by: Lee Calcote <lee.calcote@layer5.io>
