### PR TITLE
fix: flag provided but not defined: -broker-url

### DIFF
--- a/integration-tests/default_cluster_test_cases_test.go
+++ b/integration-tests/default_cluster_test_cases_test.go
@@ -51,7 +51,6 @@ var defaultClusterTestCasesData []defaultClusterTestCaseStruct = []defaultCluste
 			assert.True(t, ok, "must get count from result map")
 			if ok {
 				t.Logf("received %d messages from broker", count)
-				// TODO some more meaningful check
 				assert.True(t, count > 0, "must receive messages from queue")
 			}
 
@@ -290,6 +289,36 @@ var defaultClusterTestCasesData []defaultClusterTestCaseStruct = []defaultCluste
 					assert.Equal(t, expectedNamespace, namespace, "namespace must match expected namespace")
 				}
 			}
+		},
+	},
+	{
+		name: "must not fail with a --broker-url param",
+		meshsyncCMDArgs: []string{
+			"--broker-url", "10.96.235.19:4222",
+			"--stopAfterSeconds", "8",
+		},
+		natsMessageHandler: func(
+			t *testing.T,
+			out chan *broker.Message,
+			resultData map[string]any,
+		) {
+			count := 0
+			resultData["count"] = count
+			go func() {
+				for range out {
+					count++
+					resultData["count"] = count
+				}
+			}()
+		},
+		finalHandler: func(t *testing.T, resultData map[string]any) {
+			count, ok := resultData["count"].(int)
+			assert.True(t, ok, "must get count from result map")
+			if ok {
+				t.Logf("received %d messages from broker", count)
+				assert.True(t, count > 0, "must receive messages from queue")
+			}
+
 		},
 	},
 }

--- a/main.go
+++ b/main.go
@@ -267,6 +267,13 @@ func connectivityTest(url string, log logger.Handler) error {
 }
 
 func parseFlags() {
+	notUsedBrokerURL := ""
+	flag.StringVar(
+		&notUsedBrokerURL,
+		"broker-url",
+		"",
+		"this param is not used",
+	)
 	flag.StringVar(
 		&config.OutputMode,
 		"output",

--- a/main.go
+++ b/main.go
@@ -272,7 +272,7 @@ func parseFlags() {
 		&notUsedBrokerURL,
 		"broker-url",
 		"",
-		"this param is not used",
+		"Broker URL (note: primarily configured via BROKER_URL env var; this flag is for compatibility and its value is ignored).",
 	)
 	flag.StringVar(
 		&config.OutputMode,


### PR DESCRIPTION
**Description**

This PR fixes an issue with undefined flag --broker-url

**Notes for Reviewers**

After we did https://github.com/meshery/meshsync/releases/tag/v0.8.7 meshsync is now failing to start in deployment with an error: `flag provided but not defined: -broker-url` 

the actual code is not using this param, it uses it from env variable.
Added stub for broker-url for compatibility.

![meshsync-nroker-url-2](https://github.com/user-attachments/assets/26b717fb-4a87-4d29-b674-15d080c802a8)
![meshsync-broker-url](https://github.com/user-attachments/assets/87bffd3f-d1f3-4099-8cc8-407afd6e9446)


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
