### PR TITLE
feature: meshsync as a library: perform crd watch only if they present in the cluster

### DIFF
--- a/pkg/lib/meshsync/meshsync.go
+++ b/pkg/lib/meshsync/meshsync.go
@@ -182,7 +182,9 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 	}
 	defer meshsyncHandler.ShutdownInformer()
 
-	go meshsyncHandler.WatchCRDs()
+	if useCRDFlag {
+		go meshsyncHandler.WatchCRDs()
+	}
 
 	go meshsyncHandler.Run()
 	if options.OutputMode == config.OutputModeBroker {


### PR DESCRIPTION

**Description**

This PR fixes  the behavior of meshsync to execute watch CRDs code only if CRDs are present in the cluster. 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
