### PR TITLE
update: Handler::WatchCRDs: update log level to Debug when event.Object is nil to prevent log pollution

### DIFF
--- a/meshsync/handlers.go
+++ b/meshsync/handlers.go
@@ -285,7 +285,7 @@ func (h *Handler) WatchCRDs() {
 		if event.Object == nil {
 			// TODO
 			// https://github.com/meshery/meshsync/issues/434
-			h.Log.Info("Handler::WatchCRDs::processEvent event.Object is nil, skipping")
+			h.Log.Debug("Handler::WatchCRDs::processEvent event.Object is nil, skipping")
 			return
 		}
 		byt, err := json.Marshal(event.Object)
@@ -301,7 +301,7 @@ func (h *Handler) WatchCRDs() {
 		}
 
 		if len(crd.Spec.Versions) == 0 {
-			h.Log.Warnf(
+			h.Log.Debugf(
 				"Handler::WatchCRDs::processEvent: event.Object has empty spec.Versions [%s]",
 				string(byt),
 			)


### PR DESCRIPTION

**Description**

This PR update the log level for logging in watchCRDs function. 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
