### PR TITLE
feature: meshsync as a library: allow stop execution of Run() goroutine when cancel context oassed from client code

### DIFF
--- a/pkg/lib/meshsync/meshsync.go
+++ b/pkg/lib/meshsync/meshsync.go
@@ -57,7 +57,7 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 	crdConfigs, errGetMeshsyncCRDConfigs := getMeshsyncCRDConfigs(useCRDFlag, kubeClient)
 	if errGetMeshsyncCRDConfigs != nil {
 		// no configs found from meshsync CRD log warning
-		log.Warn(err)
+		log.Warnf("meshsync: %v", errGetMeshsyncCRDConfigs)
 	}
 	// Config init and seed
 	cfg, err := config.New(options.MeshkitConfigProvider)
@@ -72,9 +72,9 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 	}
 
 	if useCRDFlag {
-		// this patch only make sense when CRD is present in cluster
+		// this patch only make sense when CRD is present when in cluster
 		if errPatchCRVersion := config.PatchCRVersion(&kubeClient.RestConfig); errPatchCRVersion != nil {
-			log.Warn(errPatchCRVersion)
+			log.Warnf("meshsync: %v", errPatchCRVersion)
 		}
 	}
 
@@ -186,7 +186,9 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 		go meshsyncHandler.WatchCRDs()
 	}
 
+	// Start the main meshsync run
 	go meshsyncHandler.Run()
+
 	if options.OutputMode == config.OutputModeBroker {
 		// even so the config param name starts with OutputMode
 		// it is not only output but also input
@@ -199,12 +201,12 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 	if options.StopAfterDuration > -1 {
 		go func(ch chan struct{}) {
 			<-time.After(options.StopAfterDuration)
-			log.Infof("Stopping after %s", options.StopAfterDuration)
+			log.Infof("meshsync: stopping after %s", options.StopAfterDuration)
 			close(chTimeout)
 		}(chTimeout)
 	}
 
-	log.Info("MeshSync run started")
+	log.Info("meshsync: run started")
 	// Handle graceful shutdown
 	signal.Notify(chPool[channels.OS].(channels.OSChannel), syscall.SIGTERM, os.Interrupt)
 
@@ -220,9 +222,14 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 		closeOnce.Do(func() {
 			close(chPool[channels.Stop].(channels.StopChannel))
 		})
+	case <-options.Context.Done():
+		log.Info("meshsync: cancellation signal received from client code")
+		closeOnce.Do(func() {
+			close(chPool[channels.Stop].(channels.StopChannel))
+		})
 	}
 
-	log.Info("MeshSync run shutting down")
+	log.Info("meshsync: shutting down")
 
 	return nil
 }
@@ -237,14 +244,14 @@ func connectivityTest(log logger.Handler, pingEndpoint string, url string) error
 	for {
 		resp, err := http.Get(pingURL) //nolint
 		if err != nil {
-			log.Info("could not connect to broker: " + err.Error() + " retrying...")
+			log.Info("meshsync: could not connect to broker: " + err.Error() + " retrying...")
 			time.Sleep(1 * time.Second)
 			continue
 		}
 		if resp.StatusCode == http.StatusOK {
 			break
 		}
-		log.Info("could not receive OK response from broker: "+pingURL, " retrying...")
+		log.Info("meshsync: could not receive OK response from broker: "+pingURL, " retrying...")
 		time.Sleep(1 * time.Second)
 	}
 
@@ -282,12 +289,12 @@ func determineUseCRDFlag(
 	useCRDFlag := crd != nil && errGetMeshsyncCRD == nil
 	if useCRDFlag {
 		log.Infof(
-			"running in %s output mode and meshsync CRD is present in the cluster",
+			"meshsync: running in %s output mode and meshsync CRD is present in the cluster",
 			options.OutputMode,
 		)
 	} else {
 		log.Infof(
-			"running in %s mode and NO meshsync CRD is present in the cluster",
+			"meshsync: running in %s mode and NO meshsync CRD is present in the cluster",
 			options.OutputMode,
 		)
 	}

--- a/pkg/lib/meshsync/options.go
+++ b/pkg/lib/meshsync/options.go
@@ -1,6 +1,7 @@
 package meshsync
 
 import (
+	"context"
 	"time"
 
 	"github.com/meshery/meshkit/broker"
@@ -14,6 +15,7 @@ type Options struct {
 	KubeConfig        []byte
 	OutputFileName    string
 	BrokerHandler     broker.Handler
+	Context           context.Context
 
 	Version               string
 	PingEndpoint          string
@@ -24,6 +26,7 @@ var DefautOptions = Options{
 	StopAfterDuration: -1,  // -1 turns it off
 	KubeConfig:        nil, // if nil, truies to detekt kube config by the means of github.com/meshery/meshkit/utils/kubernetes/client.go:DetectKubeConfig
 	BrokerHandler:     nil, // if nil, will instantiate broker connection itself
+	Context:           context.Background(),
 
 	Version:               "Not Set",
 	PingEndpoint:          ":8222/connz",
@@ -66,6 +69,12 @@ func WithOutputFileName(value string) OptionsSetter {
 func WithBrokerHandler(value broker.Handler) OptionsSetter {
 	return func(o *Options) {
 		o.BrokerHandler = value
+	}
+}
+
+func WithContext(value context.Context) OptionsSetter {
+	return func(o *Options) {
+		o.Context = value
 	}
 }
 


### PR DESCRIPTION
**Description**

This PR fixes add an option to stop libmeshsync.Run() by canceling the context passed from above. 

**Notes for Reviewers**

- Add context to options;
- Add listen to option.Context.Done;
- Logs updates;

this is required for be able to stop execution when we use it in meshery server, when remove meshsync data handler.



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
