### PR TITLE
chore: output mode file: generate extended file if explicit option sp…

### DIFF
--- a/pkg/lib/meshsync/options.go
+++ b/pkg/lib/meshsync/options.go
@@ -10,12 +10,13 @@ import (
 )
 
 type Options struct {
-	OutputMode        string
-	StopAfterDuration time.Duration
-	KubeConfig        []byte
-	OutputFileName    string
-	BrokerHandler     broker.Handler
-	Context           context.Context
+	OutputMode         string
+	StopAfterDuration  time.Duration
+	KubeConfig         []byte
+	OutputFileName     string
+	OutputExtendedFile bool
+	BrokerHandler      broker.Handler
+	Context            context.Context
 
 	Version               string
 	PingEndpoint          string
@@ -23,10 +24,11 @@ type Options struct {
 }
 
 var DefautOptions = Options{
-	StopAfterDuration: -1,  // -1 turns it off
-	KubeConfig:        nil, // if nil, truies to detekt kube config by the means of github.com/meshery/meshkit/utils/kubernetes/client.go:DetectKubeConfig
-	BrokerHandler:     nil, // if nil, will instantiate broker connection itself
-	Context:           context.Background(),
+	StopAfterDuration:  -1,    // -1 turns it off
+	KubeConfig:         nil,   // if nil, truies to detekt kube config by the means of github.com/meshery/meshkit/utils/kubernetes/client.go:DetectKubeConfig
+	OutputExtendedFile: false, // if true, then extended output file is generated in addition to general one
+	BrokerHandler:      nil,   // if nil, will instantiate broker connection itself
+	Context:            context.Background(),
 
 	Version:               "Not Set",
 	PingEndpoint:          ":8222/connz",
@@ -63,6 +65,12 @@ func WithKubeConfig(value []byte) OptionsSetter {
 func WithOutputFileName(value string) OptionsSetter {
 	return func(o *Options) {
 		o.OutputFileName = value
+	}
+}
+
+func WithOutputExtendedFile(value bool) OptionsSetter {
+	return func(o *Options) {
+		o.OutputExtendedFile = value
 	}
 }
 


### PR DESCRIPTION
…ecified

**Description**

This PR fixes updates the logic of generation of output files in output mode = file. 

**Notes for Reviewers**
Right now in output mode file two files are generated:
- file.yaml
- file-extended.yaml

extended version contains all messages from nats, while just file.yaml peforms deduplication logic and contains only unique records. 

current pr introduce an option to generate extended file and only generates extended file if this option is set. 


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
