### PR TITLE
Chore simple output resources filtration

### DIFF
--- a/integration-tests/meshsync_as_binary_with_k8s_cluster_test_cases_mode_a_broker_test.go
+++ b/integration-tests/meshsync_as_binary_with_k8s_cluster_test_cases_mode_a_broker_test.go
@@ -102,7 +102,7 @@ var meshsyncBinaryWithK8SClusterBrokerModeTestsCasesData []meshsyncBinaryWithK8S
 		meshsyncCMDArgs: []string{
 			"--stopAfter",
 			"8s",
-			"--outputNamespace",
+			"--outputNamespaces",
 			"agile-otter",
 		},
 		brokerMessageHandler: func(

--- a/integration-tests/meshsync_as_binary_with_k8s_cluster_test_cases_mode_b_file_test.go
+++ b/integration-tests/meshsync_as_binary_with_k8s_cluster_test_cases_mode_b_file_test.go
@@ -62,7 +62,7 @@ var meshSyncBinaryWithK8SClusterFileModeTestCasesData []meshsyncBinaryWithK8SClu
 			"--stopAfter", "8s",
 			"--output", "file",
 			"--outputResources", "pod,deployment",
-			"--outputNamespace", "agile-otter",
+			"--outputNamespaces", "agile-otter",
 			"--outputFile", "meshery-cluster-snapshot-integration-test-file-mode-01.yaml",
 		},
 		setupHooks: []func(){

--- a/internal/config/pluralise.go
+++ b/internal/config/pluralise.go
@@ -1,0 +1,17 @@
+package config
+
+import "strings"
+
+func pluralize(word string) string {
+	lower := strings.ToLower(word)
+	switch {
+	case strings.HasSuffix(lower, "s"),
+		strings.HasSuffix(lower, "x"),
+		strings.HasSuffix(lower, "z"),
+		strings.HasSuffix(lower, "ch"),
+		strings.HasSuffix(lower, "sh"):
+		return word + "es"
+	default:
+		return word + "s"
+	}
+}

--- a/internal/config/pluralise_test.go
+++ b/internal/config/pluralise_test.go
@@ -1,0 +1,36 @@
+package config
+
+import "testing"
+
+func TestPluralize(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"pod", "pods"},
+		{"ingress", "ingresses"},
+		{"replicaset", "replicasets"},
+		{"configmap", "configmaps"},
+		{"job", "jobs"},
+		{"endpoint", "endpoints"},
+		{"cronjob", "cronjobs"},
+		{"customresourcedefinition", "customresourcedefinitions"},
+		{"storageclass", "storageclasses"},
+		{"clusterrole", "clusterroles"},
+		{"box", "boxes"},
+		{"buzz", "buzzes"},
+		{"church", "churches"},
+		{"bush", "bushes"},
+		{"cat", "cats"},
+		{"bus", "buses"},
+		{"fox", "foxes"},
+		{"quiz", "quizes"}, // with respect to English it is not plural, but it fits in our logic
+	}
+
+	for _, test := range tests {
+		got := pluralize(test.input)
+		if got != test.expected {
+			t.Errorf("pluralize(%q) = %q; want %q", test.input, got, test.expected)
+		}
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -89,7 +89,7 @@ func (s OutputNamespaceSet) Contains(value string) bool {
 type OutputResourceSet map[string]bool
 
 func (s OutputResourceSet) Contains(value string) bool {
-	return len(s) > 0 && s[value]
+	return s[value]
 }
 
 func NewOutputResourceSet(resources []string) OutputResourceSet {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"strings"
+
 	"golang.org/x/exp/slices"
 )
 
@@ -94,7 +96,9 @@ func NewOutputResourceSet(resources []string) OutputResourceSet {
 	set := make(OutputResourceSet, len(resources))
 
 	for _, resource := range resources {
-		set[resource] = true
+		resourceToLower := strings.ToLower(resource)
+		set[resourceToLower] = true
+		set[pluralize(resourceToLower)] = true
 	}
 
 	return set

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -83,7 +83,7 @@ func NewOutputNamespaceSet(namespaces ...string) OutputNamespaceSet {
 }
 
 func (s OutputNamespaceSet) Contains(value string) bool {
-	return len(s) > 0 && s[value]
+	return s[value]
 }
 
 type OutputResourceSet map[string]bool

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -21,14 +21,6 @@ const (
 	OutputModeFile    = "file"
 )
 
-// Command line input params
-// TODO do not have global config variables
-var (
-	OutputNamespace              string
-	OutputResourcesSet           map[string]bool
-	OutputOnlySpecifiedResources bool
-)
-
 type PipelineConfigs []PipelineConfig
 
 func (p PipelineConfigs) Add(pc PipelineConfig) PipelineConfigs {
@@ -74,4 +66,51 @@ type MeshsyncConfig struct {
 type ResourceConfig struct {
 	Resource string
 	Events   []string
+}
+
+type OutputNamespaceSet map[string]bool
+
+func NewOutputNamespaceSet(namespaces ...string) OutputNamespaceSet {
+	set := make(OutputNamespaceSet, len(namespaces))
+
+	for _, namespace := range namespaces {
+		set[namespace] = true
+	}
+
+	return set
+}
+
+func (s OutputNamespaceSet) Contains(value string) bool {
+	return len(s) > 0 && s[value]
+}
+
+type OutputResourceSet map[string]bool
+
+func (s OutputResourceSet) Contains(value string) bool {
+	return len(s) > 0 && s[value]
+}
+
+func NewOutputResourceSet(resources []string) OutputResourceSet {
+	set := make(OutputResourceSet, len(resources))
+
+	for _, resource := range resources {
+		set[resource] = true
+	}
+
+	return set
+}
+
+type OutputFiltrationContainer struct {
+	NamespaceSet OutputNamespaceSet
+	ResourceSet  OutputResourceSet
+}
+
+func NewOutputFiltrationContainer(
+	namespaceSet OutputNamespaceSet,
+	resourceSet OutputResourceSet,
+) OutputFiltrationContainer {
+	return OutputFiltrationContainer{
+		NamespaceSet: namespaceSet,
+		ResourceSet:  resourceSet,
+	}
 }

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -104,7 +104,7 @@ func (ri *RegisterInformer) publishItem(obj *unstructured.Unstructured, evtype b
 	return nil
 }
 
-func (ri *RegisterInformer) checkMustSkip(obj *unstructured.Unstructured, k8sResource model.KubernetesResource) bool {
+func (ri *RegisterInformer) checkMustSkip(obj *unstructured.Unstructured) bool {
 	if obj == nil {
 		return true
 	}

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -85,7 +85,7 @@ func (ri *RegisterInformer) publishItem(obj *unstructured.Unstructured, evtype b
 	}
 	k8sResource := model.ParseList(*obj, evtype, ri.clusterID)
 
-	if ri.checkMustSkip(obj, k8sResource) {
+	if ri.checkMustSkip(obj) {
 		// skip this resource
 		ri.log.Info("RegisterInformer::publishItem: skipping resource: ", obj.GetName(), "/", obj.GetNamespace(), " of kind: ", k8sResource.Kind)
 		return nil

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/meshery/meshkit/broker"
 	internalconfig "github.com/meshery/meshsync/internal/config"
@@ -114,10 +113,6 @@ func (ri *RegisterInformer) checkMustSkip(obj *unstructured.Unstructured, k8sRes
 		func() bool {
 			return len(ri.outputFiltration.NamespaceSet) > 0 &&
 				!ri.outputFiltration.NamespaceSet.Contains(obj.GetNamespace())
-		},
-		func() bool {
-			return len(ri.outputFiltration.ResourceSet) > 0 &&
-				!ri.outputFiltration.ResourceSet.Contains(strings.ToLower(k8sResource.Kind))
 		},
 	}
 

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -74,6 +74,11 @@ func (ri *RegisterInformer) registerHandlers(s cache.SharedIndexInformer) {
 }
 
 func (ri *RegisterInformer) publishItem(obj *unstructured.Unstructured, evtype broker.EventType, config internalconfig.PipelineConfig) error {
+	if obj == nil {
+		// skip nik resource
+		ri.log.Debug("RegisterInformer::publishItem: skipping nil resource for even type ", evtype)
+		return nil
+	}
 
 	// if the event is not supported skip
 	if !slices.Contains(ri.config.Events, string(evtype)) {
@@ -81,21 +86,9 @@ func (ri *RegisterInformer) publishItem(obj *unstructured.Unstructured, evtype b
 	}
 	k8sResource := model.ParseList(*obj, evtype, ri.clusterID)
 
-	mustSkip := false
-
-	if internalconfig.OutputNamespace != "" &&
-		obj.GetNamespace() != internalconfig.OutputNamespace {
-		mustSkip = true
-	}
-
-	if internalconfig.OutputOnlySpecifiedResources &&
-		!internalconfig.OutputResourcesSet[strings.ToLower(k8sResource.Kind)] {
-		mustSkip = true
-	}
-
-	if mustSkip {
+	if ri.checkMustSkip(obj, k8sResource) {
 		// skip this resource
-		ri.log.Info("Skipping resource: ", obj.GetName(), "/", obj.GetNamespace(), " of kind: ", k8sResource.Kind)
+		ri.log.Info("RegisterInformer::publishItem: skipping resource: ", obj.GetName(), "/", obj.GetNamespace(), " of kind: ", k8sResource.Kind)
 		return nil
 
 	}
@@ -110,4 +103,29 @@ func (ri *RegisterInformer) publishItem(obj *unstructured.Unstructured, evtype b
 	}
 
 	return nil
+}
+
+func (ri *RegisterInformer) checkMustSkip(obj *unstructured.Unstructured, k8sResource model.KubernetesResource) bool {
+	if obj == nil {
+		return true
+	}
+
+	conditions := []func() bool{
+		func() bool {
+			return len(ri.outputFiltration.NamespaceSet) > 0 &&
+				!ri.outputFiltration.NamespaceSet.Contains(obj.GetNamespace())
+		},
+		func() bool {
+			return len(ri.outputFiltration.ResourceSet) > 0 &&
+				!ri.outputFiltration.ResourceSet.Contains(strings.ToLower(k8sResource.Kind))
+		},
+	}
+
+	for _, condition := range conditions {
+		if condition() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -80,7 +80,7 @@ func New(
 	return clusterPipeline
 }
 
-func shouldFiletrOutByName(name string, resourcesSet internalconfig.OutputResourceSet) bool {
+func shouldFilterOutByName(name string, resourcesSet internalconfig.OutputResourceSet) bool {
 	if len(resourcesSet) == 0 {
 		// only filter out if there are resources restriction provided
 		return false

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -87,11 +87,6 @@ func shouldFilterOutByName(name string, resourcesSet internalconfig.OutputResour
 	}
 
 	parts := strings.Split(name, ".")
-	if len(parts) == 0 {
-		// this is probably some invalid configuration,
-		// but it is not related to our filtration, so do not filter out
-		return false
-	}
 
 	return !resourcesSet.Contains(parts[0])
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -36,19 +36,20 @@ func New(
 	plConfigs map[string]internalconfig.PipelineConfigs,
 	stopChan chan struct{},
 	clusterID string,
+	outputFiltration internalconfig.OutputFiltrationContainer,
 ) *pipeline.Pipeline {
 	// Global discovery
 	gdstage := GlobalDiscoveryStage
 	configs := plConfigs[gdstage.Name]
 	for _, config := range configs {
-		gdstage.AddStep(newRegisterInformerStep(log, informer, config, ow, clusterID)) // Register the informers for different resources
+		gdstage.AddStep(newRegisterInformerStep(log, informer, config, ow, clusterID, outputFiltration)) // Register the informers for different resources
 	}
 
 	// Local discovery
 	ldstage := LocalDiscoveryStage
 	configs = plConfigs[ldstage.Name]
 	for _, config := range configs {
-		ldstage.AddStep(newRegisterInformerStep(log, informer, config, ow, clusterID)) // Register the informers for different resources
+		ldstage.AddStep(newRegisterInformerStep(log, informer, config, ow, clusterID, outputFiltration)) // Register the informers for different resources
 	}
 
 	// Start informers

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -44,7 +44,7 @@ func New(
 	gdstage := GlobalDiscoveryStage
 	configs := plConfigs[gdstage.Name]
 	for _, config := range configs {
-		if shouldFiletrOutByName(config.Name, outputFiltration.ResourceSet) {
+		if shouldFilterOutByName(config.Name, outputFiltration.ResourceSet) {
 			// do not register informer for this config
 			continue
 		}
@@ -55,7 +55,7 @@ func New(
 	ldstage := LocalDiscoveryStage
 	configs = plConfigs[ldstage.Name]
 	for _, config := range configs {
-		if shouldFiletrOutByName(config.Name, outputFiltration.ResourceSet) {
+		if shouldFilterOutByName(config.Name, outputFiltration.ResourceSet) {
 			// do not register informer for this config
 			continue
 		}

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -14,11 +14,12 @@ import (
 
 type RegisterInformer struct {
 	pipeline.StepContext
-	log          logger.Handler
-	informer     dynamicinformer.DynamicSharedInformerFactory
-	config       internalconfig.PipelineConfig
-	outputWriter output.Writer
-	clusterID    string
+	log              logger.Handler
+	informer         dynamicinformer.DynamicSharedInformerFactory
+	config           internalconfig.PipelineConfig
+	outputWriter     output.Writer
+	clusterID        string
+	outputFiltration internalconfig.OutputFiltrationContainer
 }
 
 func newRegisterInformerStep(
@@ -27,13 +28,15 @@ func newRegisterInformerStep(
 	config internalconfig.PipelineConfig,
 	ow output.Writer,
 	clusterID string,
+	outputFiltration internalconfig.OutputFiltrationContainer,
 ) *RegisterInformer {
 	return &RegisterInformer{
-		log:          log,
-		informer:     informer,
-		config:       config,
-		outputWriter: ow,
-		clusterID:    clusterID,
+		log:              log,
+		informer:         informer,
+		config:           config,
+		outputWriter:     ow,
+		clusterID:        clusterID,
+		outputFiltration: outputFiltration, // this is a hack, should subscribe to only necessary informer instead
 	}
 }
 

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -36,7 +36,7 @@ func newRegisterInformerStep(
 		config:           config,
 		outputWriter:     ow,
 		clusterID:        clusterID,
-		outputFiltration: outputFiltration, // this is a hack, should subscribe to only necessary informer instead
+		outputFiltration: outputFiltration,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func parseFlags() {
 		&outputNamespacesString,
 		"outputNamespaces",
 		"",
-		"k8s namespaces for which limit the output, comma separated case insensitive list f.e. \"default,agile-otter\", applicable for both nats and file output mode",
+		"k8s namespaces for which limit the output, comma separated list f.e. \"default,agile-otter\", applicable for both nats and file output mode",
 	)
 	var outputResourcesString string
 	flag.StringVar(

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func parseFlags() {
 		&outputResourcesString,
 		"outputResources",
 		"",
-		"k8s resources for which limit the output, coma separated case insensitive list of k8s resources, f.e. \"pod,deployment,service\", applicable for both nats and file output mode",
+		"k8s resources for which limit the output, comma separated case insensitive list of k8s resources, f.e. \"pod,deployment,service\", applicable for both nats and file output mode",
 	)
 	flag.DurationVar(
 		&stopAfterDuration,

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ var (
 var (
 	outputMode        string
 	outputFileName    string
+	outputNamespaces  []string
+	outputResources   []string
 	stopAfterDuration time.Duration
 )
 
@@ -49,6 +51,8 @@ func main() {
 		log,
 		libmeshsync.WithOutputMode(outputMode),
 		libmeshsync.WithOutputFileName(outputFileName),
+		libmeshsync.WithOnlyK8sNamespaces(outputNamespaces...),
+		libmeshsync.WithOnlyK8sResources(outputResources),
 		libmeshsync.WithStopAfterDuration(stopAfterDuration),
 		libmeshsync.WithVersion(version),
 		libmeshsync.WithPingEndpoint(pingEndpoint),
@@ -79,11 +83,12 @@ func parseFlags() {
 		"",
 		"output file where to put the meshsync events (cluster snapshot), only applicable for file output mode (default \"./meshery-cluster-snapshot-YYYYMMDD-00.yaml\")",
 	)
+	var outputNamespacesString string
 	flag.StringVar(
-		&config.OutputNamespace,
-		"outputNamespace",
+		&outputNamespacesString,
+		"outputNamespaces",
 		"",
-		"k8s namespace for which limit the output, f.e. \"default\", applicable for both nats and file output mode",
+		"k8s namespaces for which limit the output, coma separated case insensitive list f.e. \"default,agile-otter\", applicable for both nats and file output mode",
 	)
 	var outputResourcesString string
 	flag.StringVar(
@@ -102,12 +107,13 @@ func parseFlags() {
 	// Parse the command=line flags to get the output mode
 	flag.Parse()
 
-	config.OutputResourcesSet = make(map[string]bool)
+	outputNamespacesString = strings.TrimSpace((outputNamespacesString))
+	if outputNamespacesString != "" {
+		outputNamespaces = strings.Split(outputNamespacesString, ",")
+	}
+
+	outputResourcesString = strings.TrimSpace((outputResourcesString))
 	if outputResourcesString != "" {
-		config.OutputOnlySpecifiedResources = true
-		outputResourcesList := strings.Split(outputResourcesString, ",")
-		for _, item := range outputResourcesList {
-			config.OutputResourcesSet[strings.ToLower(item)] = true
-		}
+		outputResources = strings.Split(outputResourcesString, ",")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func parseFlags() {
 		&outputNamespacesString,
 		"outputNamespaces",
 		"",
-		"k8s namespaces for which limit the output, coma separated case insensitive list f.e. \"default,agile-otter\", applicable for both nats and file output mode",
+		"k8s namespaces for which limit the output, comma separated case insensitive list f.e. \"default,agile-otter\", applicable for both nats and file output mode",
 	)
 	var outputResourcesString string
 	flag.StringVar(

--- a/meshsync/discovery.go
+++ b/meshsync/discovery.go
@@ -29,7 +29,7 @@ func (h *Handler) startDiscovery(pipelineCh chan struct{}) {
 	}
 
 	h.Log.Info("Pipeline started")
-	pl := pipeline.New(h.Log, h.informer, h.outputWriter, pipelineConfigs, pipelineCh, h.clusterID)
+	pl := pipeline.New(h.Log, h.informer, h.outputWriter, pipelineConfigs, pipelineCh, h.clusterID, h.outputFiltration)
 	result := pl.Run()
 	h.stores = result.Data.(map[string]cache.Store)
 	if result.Error != nil {

--- a/meshsync/meshsync.go
+++ b/meshsync/meshsync.go
@@ -6,6 +6,7 @@ import (
 	"github.com/meshery/meshkit/logger"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	"github.com/meshery/meshsync/internal/channels"
+	internalconfig "github.com/meshery/meshsync/internal/config"
 	"github.com/meshery/meshsync/internal/output"
 	iutils "github.com/meshery/meshsync/pkg/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,12 +22,13 @@ type Handler struct {
 	Log    logger.Handler
 	Broker broker.Handler
 
-	clusterID    string
-	informer     dynamicinformer.DynamicSharedInformerFactory
-	kubeClient   *mesherykube.Client
-	channelPool  map[string]channels.GenericChannel
-	stores       map[string]cache.Store
-	outputWriter output.Writer
+	clusterID        string
+	informer         dynamicinformer.DynamicSharedInformerFactory
+	kubeClient       *mesherykube.Client
+	channelPool      map[string]channels.GenericChannel
+	stores           map[string]cache.Store
+	outputWriter     output.Writer
+	outputFiltration internalconfig.OutputFiltrationContainer
 }
 
 func GetListOptionsFunc(config config.Handler) (func(*v1.ListOptions), error) {
@@ -57,6 +59,7 @@ func New(
 	br broker.Handler,
 	ow output.Writer,
 	pool map[string]channels.GenericChannel,
+	outputFiltration internalconfig.OutputFiltrationContainer,
 ) (*Handler, error) {
 	listOptionsFunc, err := GetListOptionsFunc(config)
 	if err != nil {
@@ -67,14 +70,15 @@ func New(
 	informer := GetDynamicInformer(config, kubeClient.DynamicKubeClient, listOptionsFunc)
 
 	return &Handler{
-		Config:       config,
-		Log:          log,
-		Broker:       br,
-		outputWriter: ow,
-		informer:     informer,
-		kubeClient:   kubeClient,
-		clusterID:    clusterID,
-		channelPool:  pool,
+		Config:           config,
+		Log:              log,
+		Broker:           br,
+		outputWriter:     ow,
+		informer:         informer,
+		kubeClient:       kubeClient,
+		clusterID:        clusterID,
+		channelPool:      pool,
+		outputFiltration: outputFiltration,
 	}, nil
 }
 

--- a/pkg/lib/meshsync/meshsync.go
+++ b/pkg/lib/meshsync/meshsync.go
@@ -192,7 +192,18 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 	}
 
 	chPool := channels.NewChannelPool()
-	meshsyncHandler, err := meshsync.New(cfg, kubeClient, log, br, outputProcessor, chPool)
+	meshsyncHandler, err := meshsync.New(
+		cfg,
+		kubeClient,
+		log,
+		br,
+		outputProcessor,
+		chPool,
+		config.NewOutputFiltrationContainer(
+			config.NewOutputNamespaceSet(options.OnlyK8sNamespaces...),
+			config.NewOutputResourceSet(options.OnlyK8sResources),
+		),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/meshsync/options.go
+++ b/pkg/lib/meshsync/options.go
@@ -17,6 +17,8 @@ type Options struct {
 	OutputExtendedFile bool
 	BrokerHandler      broker.Handler
 	Context            context.Context
+	OnlyK8sNamespaces  []string
+	OnlyK8sResources   []string
 
 	Version               string
 	PingEndpoint          string
@@ -83,6 +85,18 @@ func WithBrokerHandler(value broker.Handler) OptionsSetter {
 func WithContext(value context.Context) OptionsSetter {
 	return func(o *Options) {
 		o.Context = value
+	}
+}
+
+func WithOnlyK8sNamespaces(value ...string) OptionsSetter {
+	return func(o *Options) {
+		o.OnlyK8sNamespaces = value
+	}
+}
+
+func WithOnlyK8sResources(value []string) OptionsSetter {
+	return func(o *Options) {
+		o.OnlyK8sResources = value
 	}
 }
 


### PR DESCRIPTION
**Description**

**Notes for Reviewers**

This PR fixes updates the output filtration which is used in otput mode file.

- remove global options and propagate options from Run function; 

- add options to libmeshsync to be able to provide list of namespaces and list of resources to which restrict resource output (this will be convenient to use from krew plugin);

- allow multiple namespace instead of single namespace;

- do not subscribe to informer for resources which are not required to output; 



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
