### PR TITLE
chore: resubscribe to watch crds if result channel of informer is closed

### DIFF
--- a/meshsync/handlers.go
+++ b/meshsync/handlers.go
@@ -264,15 +264,15 @@ func (h *Handler) WatchCRDs() {
 	h.Log.Info("meshsync::Handler::WatchCRDs: starting WatchCRDs")
 loop:
 	for {
+		// watchCRDsIteration will return if the stop channel is closed.
+		h.watchCRDsIteration()
+
+		// After an iteration, wait before the next, but also listen for a stop signal
+		// to ensure a fast shutdown.
 		select {
 		case <-h.channelPool[channels.Stop].(channels.StopChannel):
 			break loop
-		default:
-			// this set up will resubscribe to watch crds if initial watch channel is closed
-			// and will stop execution if stop channel is closed
-			h.watchCRDsIteration()
-			// small delay before retry
-			<-time.After(2 * time.Second)
+		case <-time.After(2 * time.Second):
 		}
 	}
 	h.Log.Info("meshsync::Handler::WatchCRDs: stopping WatchCRDs")

--- a/meshsync/handlers.go
+++ b/meshsync/handlers.go
@@ -301,8 +301,6 @@ func (h *Handler) watchCRDsIteration() {
 	processEvent := func(event watch.Event) {
 		crd := &kubernetes.CRDItem{}
 		if event.Object == nil {
-			// TODO
-			// https://github.com/meshery/meshsync/issues/434
 			h.Log.Debug("Handler::WatchCRDs::processEvent event.Object is nil, skipping")
 			return
 		}


### PR DESCRIPTION
**Description**

This PR fixes #434 

**Notes for Reviewers**

move the content of WatchCRDs to watchCRDsIteration
and repeat in a loop call to watchCRDsIteration until close channel is closed;


there is no need in exponential retry as there  we are doing it for case when crdWatcher.ResultChan() is closed. Which happens after some time (probably of innactivity), we only need to continue to watch, hence resubscribe. 


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
