### PR TITLE
chore: trigger integration tests on changes to go.mod go.sum, so that dependabot prs will be covered

### DIFF
--- a/.github/workflows/integration-tests-ci.yml
+++ b/.github/workflows/integration-tests-ci.yml
@@ -5,7 +5,8 @@ on:
       - "master"
     paths:
       - "**.go"
-      - "**.golden"
+      - "go.mod"
+      - "go.sum"
       - "Makefile"
       - ".github/workflows/integration-tests-ci.yml"
   pull_request:
@@ -13,7 +14,8 @@ on:
       - "master"
     paths:
       - "**.go"
-      - "**.golden"
+      - "go.mod"
+      - "go.sum"
       - "Makefile"
       - ".github/workflows/integration-tests-ci.yml"
   workflow_dispatch:


### PR DESCRIPTION
**Description**

This PR fixes #

- we don have golden files;
- add go.mod go.sum to trigger conditions, so that dependabot pr will be covered with integration tests :white_check_mark: . 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
