### PR TITLE
Add docker missing dependency in build-and-release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -25,6 +25,7 @@ jobs:
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build -o meshery-meshsync . 
   docker:
     name: Docker build and push
+    needs: [build]
     runs-on: ubuntu-22.04
     steps:
     - name: Check out code


### PR DESCRIPTION
**Description**

This PR fixes #518 

**Notes for Reviewers**
- Simple single line change: Add `needs: [build]` to the [`build-and-release`](https://github.com/meshery/meshsync/blob/master/.github/workflows/build-and-release.yml) workflow, improve CI reliability.
- Confirmed `docker` job will skip if `build` job fails.
- Confirmed `docker` job runs normally when `build` job succeeds, and will not create binary again in `docker` job.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
