### PR TITLE
[CI] Upgrade Go toolchain to 1.26.4

### DIFF
--- a/.github/agents/meshsync-code-contributor.md
+++ b/.github/agents/meshsync-code-contributor.md
@@ -25,7 +25,7 @@ You are an expert-level software engineering agent specialized in contributing t
 ## Technology Stack Expertise
 
 ### Backend (MeshSync Core)
-- **Language**: Go 1.25.5 (always check `go.mod` for consistency)
+- **Language**: Go 1.26.4 (always check `go.mod` for consistency)
 - **Key Dependencies**: Kubernetes client-go, NATS, error handling libraries
 - **Architecture**: Event-driven watchers, publishers, reconcilers
 - **Testing**: Go standard testing library, table-driven tests, integration tests
@@ -446,5 +446,4 @@ make check                # Lint check with golangci-lint
 ---
 
 **CORE MANDATE**: Deliver production-ready, maintainable contributions to MeshSync following community standards, design principles, and architectural patterns. Execute systematically with comprehensive documentation and autonomous, adaptive operation. Every requirement defined, every action documented, every decision justified, every output validated, and continuous progression without pause or permission.
-
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@main
       with:
-        go-version: '1.25'
+        go-version-file: go.mod
         check-latest: 'true'
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build -o meshery-meshsync . 
   docker:
@@ -34,7 +34,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@main
       with:
-        go-version: '1.25'
+        go-version-file: go.mod
         check-latest: 'true'
     - name: Docker login
       uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-24.04]
-        go-version: [1.25.x]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out code
@@ -22,10 +21,11 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@main
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
+          version: v2.11.4
           args:  --timeout=5m
   test:
     name: Unit tests
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: Run unit tests
         run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
      
@@ -51,6 +51,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: Build
         run: make build

--- a/.github/workflows/error-codes-updater.yml
+++ b/.github/workflows/error-codes-updater.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@main
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Run utility
         run: |

--- a/.github/workflows/integration-tests-ci.yml
+++ b/.github/workflows/integration-tests-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - name: Install Docker Compose
         run: |
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26.4 AS builder
 ARG GIT_VERSION
 ARG GIT_COMMITSHA
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/meshery/meshsync
 
 replace vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
 
-go 1.25.5
+go 1.26.4
 
 require (
 	github.com/buger/jsonparser v1.1.2

--- a/install/Makefile.core.mk
+++ b/install/Makefile.core.mk
@@ -20,7 +20,7 @@ GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 REMOTE_PROVIDER="Meshery"
 LOCAL_PROVIDER="None"
-GOVERSION = 1.25
+GOVERSION = 1.26.4
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 


### PR DESCRIPTION
**Description**

Part of meshery/meshery#19875.

Upgrades MeshSync from the Go 1.25 family to Go 1.26.4 and removes repeated workflow version pins where `go.mod` can be used as the source of truth. Pins the golangci-lint binary to a Go 1.26-compatible version that matches the repo's existing lint baseline.

**Changes**

- Updated `go.mod` to Go 1.26.4.
- Updated the Docker builder image and install makefile `GOVERSION` to 1.26.4.
- Switched GitHub Actions setup-go steps to `go-version-file: go.mod`.
- Pinned golangci-lint to `v2.11.4` in CI.
- Updated the MeshSync contributor agent note to match the module version.

**Verification**

- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `golangci-lint v2.11.4 run ./... --timeout=5m`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.