### PR TITLE
fix: parse broker URL host correctly, bound the startup retry, add health endpoints, stop self-patching spec.version

### DIFF
--- a/internal/config/crd_config.go
+++ b/internal/config/crd_config.go
@@ -4,18 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
-	"github.com/meshery/meshery-operator/pkg/client"
 	"github.com/meshery/meshkit/utils"
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 )
 
 var (
@@ -193,26 +189,4 @@ func filterBlacklistedPipelines(pipelines PipelineConfigs, blackList []string) P
 		}
 	}
 	return result
-}
-
-func PatchCRVersion(config *rest.Config) error {
-	meshsyncClient, err := client.New(config)
-	if err != nil {
-		return ErrInitConfig(fmt.Errorf("unable to update MeshSync configuration"))
-	}
-
-	patchedResource := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"version": Server["version"],
-		},
-	}
-	byt, err := utils.Marshal(patchedResource)
-	if err != nil {
-		return ErrInitConfig(fmt.Errorf("unable to update MeshSync configuration"))
-	}
-	_, err = meshsyncClient.CoreV1Alpha1().MeshSyncs("meshery").Patch(context.TODO(), crName, types.MergePatchType, []byte(byt), metav1.PatchOptions{})
-	if err != nil {
-		return ErrInitConfig(fmt.Errorf("unable to update MeshSync configuration"))
-	}
-	return nil
 }

--- a/pkg/lib/meshsync/health.go
+++ b/pkg/lib/meshsync/health.go
@@ -47,10 +47,12 @@ func (h *healthServer) handler() http.Handler {
 	return mux
 }
 
-// start serves the health endpoints on addr in a background goroutine.
+// start serves the health endpoints on addr in a background goroutine and
+// returns a stop function that shuts the server down (releasing the port and
+// goroutine — Run is a library entry point, so callers may outlive it).
 // A failure to serve (e.g. the port is already taken) is logged and otherwise
 // ignored: health reporting must never take the process down.
-func (h *healthServer) start(log logger.Handler, addr string) {
+func (h *healthServer) start(log logger.Handler, addr string) func() {
 	srv := &http.Server{
 		Addr:              addr,
 		Handler:           h.handler(),
@@ -62,4 +64,9 @@ func (h *healthServer) start(log logger.Handler, addr string) {
 			log.Warnf("meshsync: health endpoints server on %s stopped: %v", addr, err)
 		}
 	}()
+	return func() {
+		if err := srv.Close(); err != nil {
+			log.Warnf("meshsync: health endpoints server close failed: %v", err)
+		}
+	}
 }

--- a/pkg/lib/meshsync/health.go
+++ b/pkg/lib/meshsync/health.go
@@ -1,0 +1,65 @@
+package meshsync
+
+import (
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/meshery/meshkit/logger"
+)
+
+// healthServer exposes minimal liveness and readiness endpoints:
+//
+//   - GET /healthz always returns 200 and only signals that the process
+//     is alive.
+//   - GET /readyz returns 200 once markReady has been called (i.e. the
+//     broker handler has been created successfully) and 503 before that.
+type healthServer struct {
+	ready atomic.Bool
+}
+
+func newHealthServer() *healthServer {
+	return &healthServer{}
+}
+
+// markReady flips the readiness flag so that /readyz starts returning 200.
+func (h *healthServer) markReady() {
+	h.ready.Store(true)
+}
+
+// handler returns the http.Handler serving the health endpoints.
+func (h *healthServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if !h.ready.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("not ready"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	return mux
+}
+
+// start serves the health endpoints on addr in a background goroutine.
+// A failure to serve (e.g. the port is already taken) is logged and otherwise
+// ignored: health reporting must never take the process down.
+func (h *healthServer) start(log logger.Handler, addr string) {
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           h.handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Infof("meshsync: health endpoints /healthz and /readyz listening on %s", addr)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Warnf("meshsync: health endpoints server on %s stopped: %v", addr, err)
+		}
+	}()
+}

--- a/pkg/lib/meshsync/health_test.go
+++ b/pkg/lib/meshsync/health_test.go
@@ -1,0 +1,37 @@
+package meshsync
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHealthServerReadiness verifies that /healthz always reports OK and
+// that /readyz flips from 503 to 200 once markReady is called.
+func TestHealthServerReadiness(t *testing.T) {
+	h := newHealthServer()
+	srv := httptest.NewServer(h.handler())
+	defer srv.Close()
+
+	assertStatus := func(path string, expected int) {
+		t.Helper()
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+		if resp.StatusCode != expected {
+			t.Errorf("GET %s: expected status %d, got %d", path, expected, resp.StatusCode)
+		}
+	}
+
+	assertStatus("/healthz", http.StatusOK)
+	assertStatus("/readyz", http.StatusServiceUnavailable)
+
+	h.markReady()
+
+	assertStatus("/healthz", http.StatusOK)
+	assertStatus("/readyz", http.StatusOK)
+}

--- a/pkg/lib/meshsync/meshsync.go
+++ b/pkg/lib/meshsync/meshsync.go
@@ -45,9 +45,11 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 	}
 
 	// Serve liveness/readiness endpoints as early as possible so that
-	// /healthz responds even while the broker is still unreachable.
+	// /healthz responds even while the broker is still unreachable; shut them
+	// down when Run exits so library callers don't leak the port/goroutine.
 	health := newHealthServer()
-	health.start(log, ":"+config.Server["port"])
+	stopHealth := health.start(log, ":"+config.Server["port"])
+	defer stopHealth()
 
 	// Initialize kubeclient
 	// options.KubeConfig is nil by default
@@ -304,8 +306,12 @@ func connectivityTest(log logger.Handler, pingEndpoint string, brokerURL string,
 
 // pingBroker performs a single HTTP GET against the broker monitoring
 // endpoint and reports any failure to reach it or non-OK response status.
+// The client carries its own timeout: http.DefaultClient has none, and a
+// black-holed endpoint would otherwise hang the request past the overall
+// connectivityTest deadline.
 func pingBroker(pingURL string) error {
-	resp, err := http.Get(pingURL) //nolint
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(pingURL) //nolint
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/meshsync/meshsync.go
+++ b/pkg/lib/meshsync/meshsync.go
@@ -75,12 +75,11 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 		return err
 	}
 
-	if useCRDFlag {
-		// this patch only make sense when CRD is present when in cluster
-		if errPatchCRVersion := config.PatchCRVersion(&kubeClient.RestConfig); errPatchCRVersion != nil {
-			log.Warnf("meshsync: %v", errPatchCRVersion)
-		}
-	}
+	// MeshSync no longer writes its build version into its own CR: spec is the
+	// operator's (and the user's) declaration of DESIRED state — the operator
+	// maps spec.version to the image tag — so a self-report there fights the
+	// controller and can roll the Deployment to the reporter's own version.
+	// The running version is still advertised over the broker (meshsync-meta).
 
 	// pass configs from crd to default configs
 	if crdConfigs != nil {

--- a/pkg/lib/meshsync/meshsync.go
+++ b/pkg/lib/meshsync/meshsync.go
@@ -44,6 +44,11 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 		)
 	}
 
+	// Serve liveness/readiness endpoints as early as possible so that
+	// /healthz responds even while the broker is still unreachable.
+	health := newHealthServer()
+	health.start(log, ":"+config.Server["port"])
+
 	// Initialize kubeclient
 	// options.KubeConfig is nil by default
 	kubeClient, err := mesherykube.New(options.KubeConfig)
@@ -117,6 +122,9 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 			}
 			br = brokerHandler
 		}
+		// the broker handler exists (nats.New succeeded or a custom
+		// handler was provided): report ready on /readyz
+		health.markReady()
 		outputProcessor.SetOutput(
 			output.NewBrokerWriter(
 				br,

--- a/pkg/lib/meshsync/meshsync.go
+++ b/pkg/lib/meshsync/meshsync.go
@@ -2,9 +2,9 @@
 package meshsync
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path"
@@ -247,27 +247,67 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 	return nil
 }
 
-func connectivityTest(log logger.Handler, pingEndpoint string, url string) error {
-	// Make sure Broker has started before starting NATS client
-	urls := strings.Split(url, ":")
-	if len(urls) == 0 {
-		return errors.New("invalid URL")
+// connectivityTestTimeout bounds how long connectivityTest keeps retrying
+// before it gives up and returns an error.
+const connectivityTestTimeout = 5 * time.Minute
+
+// brokerHost extracts the host part of a broker URL, stripping the scheme,
+// credentials (userinfo) and port if present. URLs without a scheme, such as
+// "host:4222", are treated as nats:// URLs. IPv6 literals are returned
+// without brackets.
+func brokerHost(brokerURL string) (string, error) {
+	rawURL := brokerURL
+	if !strings.Contains(rawURL, "://") {
+		rawURL = "nats://" + rawURL
 	}
-	pingURL := "http://" + urls[0] + pingEndpoint
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid broker url %q: %w", brokerURL, err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("no host found in broker url %q", brokerURL)
+	}
+	return host, nil
+}
+
+// connectivityTest makes sure the broker monitoring endpoint is reachable
+// before the NATS client is started. It retries once per second and gives up
+// once the timeout elapses, returning an error so that the caller exits
+// visibly instead of spinning forever.
+func connectivityTest(log logger.Handler, pingEndpoint string, brokerURL string, timeout time.Duration) error {
+	host, err := brokerHost(brokerURL)
+	if err != nil {
+		return err
+	}
+	pingURL := "http://" + host + pingEndpoint
+	deadline := time.Now().Add(timeout)
 	for {
-		resp, err := http.Get(pingURL) //nolint
-		if err != nil {
-			log.Debugf("meshsync: could not connect to broker: %v retrying...", err)
-			time.Sleep(1 * time.Second)
-			continue
+		errPing := pingBroker(pingURL)
+		if errPing == nil {
+			return nil
 		}
-		if resp.StatusCode == http.StatusOK {
-			break
+		log.Warnf("meshsync: broker connectivity test failed for %s: %v, retrying...", pingURL, errPing)
+		if time.Now().After(deadline) {
+			return fmt.Errorf("broker connectivity test did not succeed within %s: %s: %w", timeout, pingURL, errPing)
 		}
-		log.Debugf("meshsync: could not receive OK response from broker: %s retrying...", pingURL)
 		time.Sleep(1 * time.Second)
 	}
+}
 
+// pingBroker performs a single HTTP GET against the broker monitoring
+// endpoint and reports any failure to reach it or non-OK response status.
+func pingBroker(pingURL string) error {
+	resp, err := http.Get(pingURL) //nolint
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected response status %q", resp.Status)
+	}
 	return nil
 }
 
@@ -276,6 +316,7 @@ func createNatsBrokerHandler(log logger.Handler, pingEndpoint string, brokerURL 
 		log,
 		pingEndpoint,
 		brokerURL,
+		connectivityTestTimeout,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/lib/meshsync/meshsync_test.go
+++ b/pkg/lib/meshsync/meshsync_test.go
@@ -1,0 +1,78 @@
+package meshsync
+
+import "testing"
+
+// TestBrokerHost verifies that the host part of a broker URL is extracted
+// correctly regardless of scheme, credentials (userinfo) or port.
+func TestBrokerHost(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "host and port without scheme",
+			input:    "host:4222",
+			expected: "host",
+		},
+		{
+			name:     "scheme prefixed",
+			input:    "nats://host:4222",
+			expected: "host",
+		},
+		{
+			name:     "token as userinfo",
+			input:    "nats://TOKEN@host:4222",
+			expected: "host",
+		},
+		{
+			name:     "user and password with tls scheme",
+			input:    "tls://user:pass@host:4222",
+			expected: "host",
+		},
+		{
+			name:     "ipv6 literal",
+			input:    "nats://[::1]:4222",
+			expected: "::1",
+		},
+		{
+			name:     "bare host",
+			input:    "host",
+			expected: "host",
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			expectErr: true,
+		},
+		{
+			name:      "scheme without host",
+			input:     "nats://",
+			expectErr: true,
+		},
+		{
+			name:      "invalid character in host",
+			input:     "nats://ho st:4222",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			host, err := brokerHost(tc.input)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got host %q", tc.input, host)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for input %q: %v", tc.input, err)
+			}
+			if host != tc.expected {
+				t.Errorf("expected host %q for input %q, got %q", tc.expected, tc.input, host)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problems (all found by deploying against a live kind cluster with meshery-operator's modernization stack)

1. **The startup connectivity test pings the wrong host for any scheme-prefixed BROKER_URL — silently, forever.** `connectivityTest` split the URL on `:` and used the first segment as the hostname, so `nats://<token>@host:4222` (what the operator now injects — token as URL userinfo, which nats.go natively supports) made it ping `http://nats:8222/connz` in an infinite 1-second retry loop, logging only at **debug** level. The pod sits Running with empty logs and zero connections on the broker. Observed live: broker `connz` at `num_connections: 0` while both deployments reported Available.

2. **MeshSync has no health signal.** No HTTP endpoint, and the image is distroless (no shell), so no meaningful probe was possible — the operator's exec `-h` probes only proved the binary could fork.

3. **MeshSync merge-patches its own build version into `spec.version` of its CR at startup** (hardcoded `meshery` namespace). `spec` is the operator's and the user's declaration of *desired* state — the operator maps `spec.version` to the image tag — so the reporter fought the controller: pinning `spec.version` rolled a new pod, which immediately patched the field back to its own version, rolling the Deployment again to an image tag that may not exist. Observed live: a pinned dev image was replaced by a rollout to a nonexistent tag within seconds. The running version is still advertised over the broker via `meshsync-meta`.

## Changes

- `brokerHost()`: proper `url.Parse`-based host extraction (scheme optional, userinfo/port/IPv6 handled), with table-driven tests.
- `connectivityTest`: logs every failed attempt at **Warn** with the ping URL, and gives up after 5 minutes returning an error — the process exits non-zero, so a dead broker is a visible CrashLoopBackOff instead of a silent spin. Also fixes a response-body leak in the ping.
- New `/healthz` (process liveness) and `/readyz` (503 until the broker handler is created) on port 11000 — the port the operator's Deployment already declares. Serving starts before the connectivity test; a bind failure logs a warning and never takes the process down.
- `PatchCRVersion` removed.

## Validation

- `go build`, `go vet`, `go test ./...`, `golangci-lint`: clean.
- **Live end-to-end** on a kind cluster via meshery-operator's integration harness with this branch's image: MeshSync authenticates to token-auth NATS via `BROKER_URL=nats://$(NATS_TOKEN)@host:4222` and holds a live client connection (asserted via the broker's `connz`), the conversion webhook round-trips, and the operator's image pinning works without being fought over.

Coordinates with meshery/meshery-operator#800 / meshery/meshery-operator#815 (tracking: meshery/meshery-operator#801, epic meshery/meshery-operator#783). The operator's e2e now asserts the live-connection contract, so a regression here turns its CI red.