### PR TITLE
[pipeline] Fix DeleteFunc panic on informer DeletedFinalStateUnknown tombstones

### DIFF
--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -46,21 +46,26 @@ func (ri *RegisterInformer) GetEventHandlers() cache.ResourceEventHandlerFuncs {
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			// the obj can only be of two types, Unstructured or DeletedFinalStateUnknown.
-			// DeletedFinalStateUnknown means that the object that we receive may be `stale`
-			// because of the way informer behaves
+			// The obj can only be of two types: *unstructured.Unstructured or
+			// cache.DeletedFinalStateUnknown. The latter is a tombstone the informer
+			// delivers after a watch gap/resync when it missed the final delete state,
+			// so its wrapped object may be `stale`.
 
 			// refer 'https://pkg.go.dev/k8s.io/client-go/tools/cache#ResourceEventHandler.OnDelete'
 
-			var objCasted *unstructured.Unstructured
-			objCasted = obj.(*unstructured.Unstructured)
-
-			possiblyStaleObj, ok := obj.(cache.DeletedFinalStateUnknown)
-			if ok {
-				objCasted = possiblyStaleObj.Obj.(*unstructured.Unstructured)
+			// Unwrap the tombstone first. Asserting *unstructured.Unstructured directly
+			// on a cache.DeletedFinalStateUnknown would panic and crash this goroutine.
+			if staleObj, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = staleObj.Obj
 			}
-			err := ri.publishItem(objCasted, broker.Delete, ri.config)
 
+			objCasted, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				ri.log.Errorf("RegisterInformer::DeleteFunc: unexpected object type %T in delete event; skipping", obj)
+				return
+			}
+
+			err := ri.publishItem(objCasted, broker.Delete, ri.config)
 			if err != nil {
 				ri.log.Error(err)
 			}

--- a/internal/pipeline/handlers.go
+++ b/internal/pipeline/handlers.go
@@ -46,10 +46,11 @@ func (ri *RegisterInformer) GetEventHandlers() cache.ResourceEventHandlerFuncs {
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			// The obj can only be of two types: *unstructured.Unstructured or
+			// obj is expected to be one of two types: *unstructured.Unstructured or
 			// cache.DeletedFinalStateUnknown. The latter is a tombstone the informer
 			// delivers after a watch gap/resync when it missed the final delete state,
-			// so its wrapped object may be `stale`.
+			// so its wrapped object may be `stale`. Anything else is handled
+			// defensively below rather than assumed away.
 
 			// refer 'https://pkg.go.dev/k8s.io/client-go/tools/cache#ResourceEventHandler.OnDelete'
 

--- a/internal/pipeline/handlers_test.go
+++ b/internal/pipeline/handlers_test.go
@@ -1,0 +1,130 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/meshery/meshkit/broker"
+	"github.com/meshery/meshkit/logger"
+	internalconfig "github.com/meshery/meshsync/internal/config"
+	"github.com/meshery/meshsync/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+)
+
+// recordingWriter is a test double for output.Writer that records every
+// resource handed to it, so tests can assert what the delete handler published.
+type recordingWriter struct {
+	written []model.KubernetesResource
+	events  []broker.EventType
+}
+
+func (w *recordingWriter) Write(obj model.KubernetesResource, evtype broker.EventType, _ internalconfig.PipelineConfig) error {
+	w.written = append(w.written, obj)
+	w.events = append(w.events, evtype)
+	return nil
+}
+
+// newTestRegisterInformer builds a RegisterInformer wired to a recordingWriter
+// with the DELETE event enabled - the minimum needed to drive DeleteFunc end to
+// end. The logger uses zero-value Options, which defaults to logrus PanicLevel
+// and therefore stays silent during the test.
+func newTestRegisterInformer(t *testing.T) (*RegisterInformer, *recordingWriter) {
+	t.Helper()
+
+	log, err := logger.New("meshsync-test", logger.Options{})
+	require.NoError(t, err)
+
+	writer := &recordingWriter{}
+	ri := &RegisterInformer{
+		log:          log,
+		outputWriter: writer,
+		config: internalconfig.PipelineConfig{
+			Name:   "pods.v1.",
+			Events: []string{string(broker.Delete)},
+		},
+		clusterID: "test-cluster",
+	}
+	return ri, writer
+}
+
+func newUnstructuredPod(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+// TestDeleteFunc_Tombstone is the regression test for the panic that occurred
+// when the informer delivered a cache.DeletedFinalStateUnknown tombstone - the
+// exact stale-delete case that happens after a watch gap/resync. The handler
+// must unwrap the tombstone and publish the wrapped object rather than panicking
+// on an unchecked type assertion.
+func TestDeleteFunc_Tombstone(t *testing.T) {
+	ri, writer := newTestRegisterInformer(t)
+	handlers := ri.GetEventHandlers()
+
+	tombstone := cache.DeletedFinalStateUnknown{
+		Key: "default/tombstoned-pod",
+		Obj: newUnstructuredPod("tombstoned-pod", "default"),
+	}
+
+	assert.NotPanics(t, func() {
+		handlers.DeleteFunc(tombstone)
+	}, "DeleteFunc must not panic on a cache.DeletedFinalStateUnknown tombstone")
+
+	require.Len(t, writer.written, 1, "the wrapped object should be published exactly once")
+	assert.Equal(t, broker.Delete, writer.events[0])
+	assert.Equal(t, "Pod", writer.written[0].Kind)
+	assert.Equal(t, "test-cluster", writer.written[0].ClusterID)
+	require.NotNil(t, writer.written[0].KubernetesResourceMeta)
+	assert.Equal(t, "tombstoned-pod", writer.written[0].KubernetesResourceMeta.Name)
+}
+
+// TestDeleteFunc_Unstructured covers the ordinary path where the informer
+// delivers the object directly as *unstructured.Unstructured.
+func TestDeleteFunc_Unstructured(t *testing.T) {
+	ri, writer := newTestRegisterInformer(t)
+	handlers := ri.GetEventHandlers()
+
+	assert.NotPanics(t, func() {
+		handlers.DeleteFunc(newUnstructuredPod("live-pod", "kube-system"))
+	})
+
+	require.Len(t, writer.written, 1)
+	assert.Equal(t, broker.Delete, writer.events[0])
+	require.NotNil(t, writer.written[0].KubernetesResourceMeta)
+	assert.Equal(t, "live-pod", writer.written[0].KubernetesResourceMeta.Name)
+}
+
+// TestDeleteFunc_UnexpectedType ensures the handler degrades gracefully - it
+// must neither panic nor publish anything - when it receives neither an
+// *unstructured.Unstructured nor a tombstone wrapping one.
+func TestDeleteFunc_UnexpectedType(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  interface{}
+	}{
+		{name: "raw unexpected type", obj: "not-an-object"},
+		{name: "tombstone wrapping unexpected type", obj: cache.DeletedFinalStateUnknown{Key: "x", Obj: "not-an-object"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ri, writer := newTestRegisterInformer(t)
+			handlers := ri.GetEventHandlers()
+
+			assert.NotPanics(t, func() {
+				handlers.DeleteFunc(tc.obj)
+			})
+			assert.Empty(t, writer.written, "nothing should be published for an unhandled object type")
+		})
+	}
+}


### PR DESCRIPTION
**Description**

The informer `DeleteFunc` in `internal/pipeline/handlers.go` crashed its handler goroutine whenever the informer delivered a `cache.DeletedFinalStateUnknown` tombstone.

- **Symptom** - `DeleteFunc` panics and takes down the handler goroutine when a delete is delivered as a `cache.DeletedFinalStateUnknown` tombstone (the stale-delete case that follows a watch gap/resync).
- **Root cause** - The handler's first statement was an unchecked, single-value type assertion `objCasted = obj.(*unstructured.Unstructured)`, placed *before* the block meant to handle the tombstone. Since a tombstone is a `cache.DeletedFinalStateUnknown` struct rather than a `*unstructured.Unstructured`, that assertion panics - so the tombstone-handling code directly below it was unreachable and could never run. A second unchecked assertion on `possiblyStaleObj.Obj` carried the same risk for a tombstone wrapping an unexpected type.
- **Fix** - Reorder to unwrap the tombstone first (`cache.DeletedFinalStateUnknown` -> `.Obj`), then assert `*unstructured.Unstructured` with the comma-ok form. This single assertion now covers both the direct object and the unwrapped tombstone. If `obj` is neither type, log via `ri.log.Errorf` (with `%T`) and return safely instead of panicking. Collapsing to one final assertion also removes the second latent panic.

This is a defensive correctness fix - no API, schema, or behavior contract changes - so no cross-repo coordination is required.

**Notes for Reviewers**

- Added `internal/pipeline/handlers_test.go` with a `recordingWriter` test double and three cases: the tombstone path (the regression), the ordinary direct-object path, and unexpected object types (raw and tombstone-wrapped) that must neither panic nor publish.
- Verified the test is a genuine regression test: temporarily restoring the old assertion makes `TestDeleteFunc_Tombstone` panic at exactly the offending line; with the fix in place all cases pass.
- Local checks all green: `go build ./...`, `go vet ./internal/pipeline/`, `gofmt -l` (clean), `golangci-lint run ./internal/pipeline/` (0 issues), and the full `internal/pipeline` package tests.
- Out of scope but worth noting: `AddFunc`/`UpdateFunc` use the same single-value `obj.(*unstructured.Unstructured)` assertion. They are lower-risk because Add/Update do not receive `DeletedFinalStateUnknown` tombstones (a malformed object there is a genuine programming error, not an expected informer state), so they were intentionally left unchanged to keep this change surgical.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
