### PR TITLE
fix(pipeline): prime informer caches on start; stop stage-step accumulation across resyncs

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -10,26 +10,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 )
 
-var (
-	Name                 = internalconfig.PipelineNameKey
-	GlobalDiscoveryStage = &pipeline.Stage{
-		Name:       internalconfig.GlobalResourceKey,
-		Concurrent: false,
-		Steps:      []pipeline.Step{},
-	}
-
-	LocalDiscoveryStage = &pipeline.Stage{
-		Name:       internalconfig.LocalResourceKey,
-		Concurrent: false,
-		Steps:      []pipeline.Step{},
-	}
-
-	StartInformersStage = &pipeline.Stage{
-		Name:       "StartInformers",
-		Concurrent: false,
-		Steps:      []pipeline.Step{},
-	}
-)
+var Name = internalconfig.PipelineNameKey
 
 func New(
 	log logger.Handler,
@@ -40,10 +21,18 @@ func New(
 	clusterID string,
 	outputFiltration internalconfig.OutputFiltrationContainer,
 ) *pipeline.Pipeline {
+	// Stages are built fresh on every call. New runs once per discovery and again
+	// on each resync, so the stages must not be shared package-level state: reusing
+	// them would accumulate steps from prior runs that hold shut-down informer
+	// factories and closed stop channels.
+
 	// Global discovery
-	gdstage := GlobalDiscoveryStage
-	configs := plConfigs[gdstage.Name]
-	for _, config := range configs {
+	gdstage := &pipeline.Stage{
+		Name:       internalconfig.GlobalResourceKey,
+		Concurrent: false,
+		Steps:      []pipeline.Step{},
+	}
+	for _, config := range plConfigs[gdstage.Name] {
 		if shouldFilterOutByName(config.Name, outputFiltration.ResourceSet) {
 			// do not register informer for this config
 			continue
@@ -52,9 +41,12 @@ func New(
 	}
 
 	// Local discovery
-	ldstage := LocalDiscoveryStage
-	configs = plConfigs[ldstage.Name]
-	for _, config := range configs {
+	ldstage := &pipeline.Stage{
+		Name:       internalconfig.LocalResourceKey,
+		Concurrent: false,
+		Steps:      []pipeline.Step{},
+	}
+	for _, config := range plConfigs[ldstage.Name] {
 		if shouldFilterOutByName(config.Name, outputFiltration.ResourceSet) {
 			// do not register informer for this config
 			continue
@@ -64,7 +56,11 @@ func New(
 	}
 
 	// Start informers
-	strtInfmrs := StartInformersStage
+	strtInfmrs := &pipeline.Stage{
+		Name:       "StartInformers",
+		Concurrent: false,
+		Steps:      []pipeline.Step{},
+	}
 	strtInfmrs.AddStep(newStartInformersStep(stopChan, log, informer)) // Start the registered informers
 
 	// Create Pipeline

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,37 @@
+package pipeline
+
+import (
+	"testing"
+
+	internalconfig "github.com/meshery/meshsync/internal/config"
+)
+
+// TestNewDoesNotAccumulateSteps guards against the discovery stages being shared
+// mutable state. New is called once per discovery, and again on every resync, so
+// each call must produce an independent pipeline. If stage state persisted across
+// calls, the stages would accumulate duplicate steps that hold stale informer
+// factories and closed stop channels from prior runs.
+func TestNewDoesNotAccumulateSteps(t *testing.T) {
+	log := newTestLogger(t)
+	// Empty configs mean no RegisterInformer steps, so a correct pipeline holds
+	// exactly one step: the single StartInformers step.
+	plConfigs := map[string]internalconfig.PipelineConfigs{}
+
+	totalSteps := func() int {
+		factory, _ := newSeededFactory(t)
+		stopChan := make(chan struct{})
+		pl := New(log, factory, nil, plConfigs, stopChan, "", internalconfig.OutputFiltrationContainer{})
+		total := 0
+		for _, st := range pl.Stages {
+			total += len(st.Steps)
+		}
+		return total
+	}
+
+	if first := totalSteps(); first != 1 {
+		t.Fatalf("first New() produced %d steps, want 1", first)
+	}
+	if second := totalSteps(); second != 1 {
+		t.Fatalf("steps accumulated across New() calls: got %d on the second call, want 1", second)
+	}
+}

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -90,9 +90,31 @@ func newStartInformersStep(stopChan chan struct{}, log logger.Handler, informer 
 	}
 }
 
+// Exec starts the registered informers, then blocks until their caches have
+// primed. The order is load-bearing: DynamicSharedInformerFactory.WaitForCacheSync
+// only waits on informers that have already been started, so Start must run
+// first. Calling WaitForCacheSync before Start makes it a no-op, so discovery
+// proceeds against unprimed caches and reports an empty or partial cluster
+// snapshot. WaitForCacheSync unblocks once every started informer has synced, or
+// early if stopChan is closed (shutdown or resync).
 func (si *StartInformers) Exec(request *pipeline.Request) *pipeline.Result {
-	si.informer.WaitForCacheSync(si.stopChan)
 	si.informer.Start(si.stopChan)
+
+	var unsynced []string
+	for gvr, ok := range si.informer.WaitForCacheSync(si.stopChan) {
+		if !ok {
+			unsynced = append(unsynced, gvr.String())
+		}
+	}
+	if len(unsynced) > 0 {
+		// A false sync result means stopChan closed before the cache primed - the
+		// discovery was stopped or resynced mid-sync, which is expected teardown
+		// rather than a hard failure, so it does not fail the pipeline step.
+		si.log.Debugf("informer caches not primed before discovery stopped: %v", unsynced)
+	} else {
+		si.log.Debug("informer caches synced")
+	}
+
 	return &pipeline.Result{
 		Error: nil,
 		Data:  request.Data,

--- a/internal/pipeline/step_test.go
+++ b/internal/pipeline/step_test.go
@@ -1,0 +1,113 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meshery/meshkit/logger"
+	"github.com/myntra/pipeline"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+var widgetGVR = schema.GroupVersionResource{Group: "meshsync.test", Version: "v1", Resource: "widgets"}
+
+func newTestLogger(t *testing.T) logger.Handler {
+	t.Helper()
+	// Quiet level: the step logs cache-sync status at Debug, which we do not want
+	// polluting test output.
+	log, err := logger.New("meshsync-test", logger.Options{
+		Format:   logger.JsonLogFormat,
+		LogLevel: int(logrus.ErrorLevel),
+	})
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	return log
+}
+
+func newWidget(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "meshsync.test", Version: "v1", Kind: "Widget"})
+	u.SetNamespace("default")
+	u.SetName(name)
+	return u
+}
+
+// newSeededFactory builds a factory over a fake dynamic client pre-loaded with
+// objs and registers the informer for widgetGVR. Registration mirrors what
+// RegisterInformer.Exec does in the earlier discovery stages, so the factory is
+// in the same state StartInformers sees in production.
+func newSeededFactory(t *testing.T, objs ...*unstructured.Unstructured) (dynamicinformer.DynamicSharedInformerFactory, cache.Store) {
+	t.Helper()
+	runtimeObjs := make([]runtime.Object, len(objs))
+	for i, o := range objs {
+		runtimeObjs[i] = o
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{widgetGVR: "WidgetList"},
+		runtimeObjs...,
+	)
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, 0, metav1.NamespaceAll, nil)
+	store := factory.ForResource(widgetGVR).Informer().GetStore()
+	return factory, store
+}
+
+// TestStartInformersExec_PrimesCache is the regression guard for the ordering
+// bug: WaitForCacheSync must run after Start. With the correct order the started
+// informers' caches are guaranteed primed by the time Exec returns. (With the
+// old Wait-before-Start order, WaitForCacheSync was a no-op and the store would
+// still be empty here.)
+func TestStartInformersExec_PrimesCache(t *testing.T) {
+	factory, store := newSeededFactory(t, newWidget("w1"), newWidget("w2"))
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+
+	step := newStartInformersStep(stopChan, newTestLogger(t), factory)
+
+	inData := map[string]cache.Store{widgetGVR.Resource: store}
+	res := step.Exec(&pipeline.Request{Data: inData})
+
+	if res.Error != nil {
+		t.Fatalf("Exec returned error: %v", res.Error)
+	}
+	if got := len(store.List()); got != 2 {
+		t.Fatalf("cache not primed synchronously: store holds %d objects, want 2", got)
+	}
+	// StartInformers is the final stage; it must pass the accumulated store map
+	// from earlier stages through untouched (discovery.go relies on this).
+	outData, ok := res.Data.(map[string]cache.Store)
+	if !ok || outData[widgetGVR.Resource] == nil {
+		t.Fatalf("Exec dropped the accumulated store map: got %#v", res.Data)
+	}
+}
+
+// TestStartInformersExec_ClosedStopChan verifies the teardown path: when
+// stopChan is already closed (shutdown or resync), WaitForCacheSync must unblock
+// so Exec returns promptly instead of hanging, and it must not surface an error.
+func TestStartInformersExec_ClosedStopChan(t *testing.T) {
+	factory, _ := newSeededFactory(t, newWidget("w1"))
+	stopChan := make(chan struct{})
+	close(stopChan)
+
+	step := newStartInformersStep(stopChan, newTestLogger(t), factory)
+
+	done := make(chan *pipeline.Result, 1)
+	go func() { done <- step.Exec(&pipeline.Request{}) }()
+
+	select {
+	case res := <-done:
+		if res.Error != nil {
+			t.Fatalf("Exec returned error on closed stopChan: %v", res.Error)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Exec blocked on a closed stopChan; WaitForCacheSync must unblock on stop")
+	}
+}


### PR DESCRIPTION
**Description**

This PR fixes two related bugs in the discovery pipeline (`internal/pipeline`).

**1. Informer caches were never awaited on start (`step.go`)**

- **Symptom** - MeshSync reports an empty or partial cluster snapshot immediately after (re)start.
- **Root cause** - `StartInformers.Exec` called `WaitForCacheSync` *before* `Start`. A `DynamicSharedInformerFactory.WaitForCacheSync` only waits on informers that have already been started (its wait set is built from `f.startedInformers`). Called before `Start`, that set is empty, so it returns an empty map instantly and waits on nothing - a no-op. Discovery then proceeded against unprimed caches.
- **Fix** - `Start` first, then `WaitForCacheSync`, so the step blocks until the started informers' caches prime (or `stopChan` closes on shutdown/resync). The previously-discarded sync result is now reported through the step's (previously unused) logger; a `false` result only occurs when `stopChan` closes mid-sync, i.e. expected teardown, so it logs at Debug rather than failing the step.

**2. Discovery stages accumulated steps across resyncs (`pipeline.go`)**

While confirming `pipeline.go` still behaved as intended, I found it did not.

- **Symptom / root cause** - the discovery stages (`GlobalDiscoveryStage`, `LocalDiscoveryStage`, `StartInformersStage`) were shared package-level mutable globals, and `New()` appended to them without ever resetting. `New()` runs once per discovery and again on every resync, so the stages accumulated duplicate steps from prior runs - steps holding shut-down informer factories and closed stop channels - growing unbounded per resync. Verified empirically: a second `New()` call produced 2 `StartInformers` steps instead of 1.
- **Fix** - build the stages as locals inside `New()` so each pipeline is independent. The exported stage vars had no other consumers and were removed.

The two fixes are complementary: without the `pipeline.go` fix, a post-fix resync would re-run stale `StartInformers`/`RegisterInformer` steps against a shut-down factory.

**Tests added**

- `step_test.go` - `TestStartInformersExec_PrimesCache` (cache is primed synchronously after `Exec`; fails on the old ordering with `store holds 0 objects`), `TestStartInformersExec_ClosedStopChan` (`Exec` returns promptly instead of hanging when `stopChan` is already closed).
- `pipeline_test.go` - `TestNewDoesNotAccumulateSteps` (guards the accumulation regression).

Each test was confirmed to fail against the pre-fix code and pass after.

**Notes for Reviewers**

- Verified against the exact client-go the repo compiles against (`v0.35.3`): `WaitForCacheSync` iterates only `startedInformers`, confirming the ordering was a no-op.
- Blocking in `StartInformers.Exec` is safe: it is the final stage and `pl.Run()` executes inside the per-discovery goroutine, so it does not stall `Handler.Run`'s Stop/ReSync loop; on resync, closing the channel cleanly unblocks the wait.
- `go build ./...`, `go vet`, and `gofmt` are clean. New tests pass race-clean (`-race -count=5`). The full module unit suite passes; `integration-tests/` were not run here as they require a live cluster and broker.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
