### PR TITLE
fix(meshsync): only resync informers on real CRD add/delete

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -30,6 +30,13 @@ func (p PipelineConfigs) Add(pc PipelineConfig) PipelineConfigs {
 	return p
 }
 
+// Contains reports whether a pipeline with the given name is already present.
+func (p PipelineConfigs) Contains(name string) bool {
+	return slices.ContainsFunc(p, func(pc PipelineConfig) bool {
+		return pc.Name == name
+	})
+}
+
 func (p PipelineConfigs) Delete(pc PipelineConfig) PipelineConfigs {
 	for index, pipelineConfig := range p {
 		if pipelineConfig.Name == pc.Name {

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -1,0 +1,20 @@
+package config
+
+import "testing"
+
+func TestPipelineConfigsContains(t *testing.T) {
+	p := PipelineConfigs{
+		{Name: "certificates.v1.cert-manager.io"},
+		{Name: "issuers.v1.cert-manager.io"},
+	}
+
+	if !p.Contains("issuers.v1.cert-manager.io") {
+		t.Error("Contains should find an existing pipeline name")
+	}
+	if p.Contains("pods.v1.") {
+		t.Error("Contains should not find an absent pipeline name")
+	}
+	if (PipelineConfigs{}).Contains("anything") {
+		t.Error("empty PipelineConfigs should contain nothing")
+	}
+}

--- a/meshsync/handlers.go
+++ b/meshsync/handlers.go
@@ -383,6 +383,10 @@ func (h *Handler) watchCRDsIteration() error {
 	if err != nil {
 		return err
 	}
+	// Stop the watcher explicitly rather than relying on ctx cancellation alone,
+	// so the streaming connection and its goroutine are released immediately when
+	// this iteration returns (stop signal, closed channel, or re-establishment).
+	defer crdWatcher.Stop()
 
 	for {
 		select {

--- a/meshsync/handlers.go
+++ b/meshsync/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -309,44 +310,88 @@ func (h *Handler) listStoreObjects() []model.KubernetesResource {
 	return parsedObjects
 }
 
+const (
+	// watchCRDsBaseDelay is the pause between CRD watch iterations under normal
+	// conditions - the API server routinely closes long-lived watches and we
+	// simply re-establish them.
+	watchCRDsBaseDelay = 2 * time.Second
+	// watchCRDsMaxDelay caps the exponential backoff applied to failing or
+	// immediately-collapsing watches so a persistently unreachable API server is
+	// retried at a steady, bounded rate instead of in a tight loop.
+	watchCRDsMaxDelay = 2 * time.Minute
+)
+
 func (h *Handler) WatchCRDs() {
 	h.Log.Debug("meshsync::Handler::WatchCRDs: starting WatchCRDs")
+
+	backoff := watchCRDsBaseDelay
 loop:
 	for {
-		// watchCRDsIteration will return if the stop channel is closed.
-		h.watchCRDsIteration()
+		// watchCRDsIteration returns nil when the stop channel is closed or the
+		// API server closes a healthy watch; it returns an error when the watch
+		// could not be established.
+		start := time.Now()
+		err := h.watchCRDsIteration()
+		lasted := time.Since(start)
 
-		// After an iteration, wait before the next, but also listen for a stop signal
+		var delay time.Duration
+		// Treat an iteration as healthy only if it ran without error for at least
+		// the base delay. A watch that errors, or that collapses almost
+		// immediately (e.g. RBAC denial, API server churn), is backed off
+		// exponentially with jitter; a watch that stayed up and cycled normally
+		// resets the backoff so routine re-establishment is not penalised.
+		if err == nil && lasted >= watchCRDsBaseDelay {
+			backoff = watchCRDsBaseDelay
+			delay = watchCRDsBaseDelay
+		} else {
+			if err != nil {
+				h.Log.Warnf("meshsync::Handler::WatchCRDs: watch iteration failed, backing off %s: %v", backoff, err)
+			} else {
+				h.Log.Debugf("meshsync::Handler::WatchCRDs: watch collapsed after %s, backing off %s", lasted, backoff)
+			}
+			delay = jitter(backoff)
+			backoff = min(backoff*2, watchCRDsMaxDelay)
+		}
+
+		// Wait before the next iteration, but wake immediately on a stop signal
 		// to ensure a fast shutdown.
 		select {
 		case <-h.channelPool[channels.Stop].(channels.StopChannel):
 			break loop
-		case <-time.After(2 * time.Second):
+		case <-time.After(delay):
 		}
 	}
 	h.Log.Debug("meshsync::Handler::WatchCRDs: stopping WatchCRDs")
 }
 
-func (h *Handler) watchCRDsIteration() {
+// jitter returns a duration in [d/2, d] to spread out watch re-establishment
+// retries and avoid many MeshSync instances retrying in lockstep against the
+// API server.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	half := d / 2
+	return half + time.Duration(rand.Int64N(int64(half)+1))
+}
+
+func (h *Handler) watchCRDsIteration() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	crdWatcher, err := h.createCRDWatcher(ctx)
-
 	if err != nil {
-		h.Log.Error(err)
-		return
+		return err
 	}
 
-loop:
 	for {
 		select {
 		case <-h.channelPool[channels.Stop].(channels.StopChannel):
-			break loop
+			return nil
 		case event, ok := <-crdWatcher.ResultChan():
 			if !ok {
 				h.Log.Debug("meshsync::Handler::watchCRDsIteration crdWatcher.ResultChan() was closed")
-				break loop
+				return nil
 			}
 			h.handleCRDEvent(event)
 		}
@@ -389,9 +434,18 @@ func (h *Handler) handleCRDEvent(event watch.Event) {
 		return
 	}
 
-	if err := h.updatePipelineConfig(event.Type, gvr); err != nil {
+	changed, err := h.updatePipelineConfig(event.Type, gvr)
+	if err != nil {
 		h.Log.Error(err)
 		h.Log.Debug("skipping informer resync")
+		return
+	}
+
+	if !changed {
+		// The set of watched resources is unchanged (e.g. a MODIFIED event), so a
+		// resync would tear down and rebuild every informer - re-listing all
+		// watched resource types cluster-wide - for no benefit. Skip it.
+		h.Log.Debugf("crd %s event for %s did not change discovery config; skipping informer resync", event.Type, gvr.String())
 		return
 	}
 
@@ -413,14 +467,22 @@ func parseCRDEvent(event watch.Event) (*kubernetes.CRDItem, []byte, error) {
 	return crd, data, nil
 }
 
+// updatePipelineConfig reflects a CRD watch event in the discovery pipeline
+// config. It returns changed=true only when the set of watched resources was
+// actually mutated (a resource registered or removed), so callers can skip the
+// expensive informer resync for events that leave discovery untouched - notably
+// MODIFIED events, which controllers such as cert-manager's cainjector emit
+// continuously as they rewrite unrelated CRD fields (e.g. the conversion webhook
+// caBundle). The GVR is derived solely from group/version/plural, none of which
+// a MODIFIED event alters, so such events never change what we watch.
 func (h *Handler) updatePipelineConfig(
 	eventType watch.EventType,
 	gvr *schema.GroupVersionResource,
-) error {
+) (changed bool, err error) {
 
 	existing := make(map[string]config.PipelineConfigs)
 	if err := h.Config.GetObject(config.ResourcesKey, &existing); err != nil {
-		return err
+		return false, err
 	}
 
 	pipelines := existing[config.GlobalResourceKey]
@@ -428,19 +490,35 @@ func (h *Handler) updatePipelineConfig(
 
 	switch eventType {
 	case watch.Added:
-		// No need to verify if config is already added because If the config already exists then it indicates the informer has already synced that resource.
-		// Any subsequent updates will have event type as "modified"
+		// Adding is idempotent. A freshly (re)established CRD watch re-lists every
+		// existing CRD as ADDED, so registering unconditionally would accumulate
+		// duplicate pipeline configs - which in turn register duplicate informer
+		// event handlers and double-publish every resource. Only register (and
+		// resync for) resources we are not already watching.
+		if pipelines.Contains(name) {
+			return false, nil
+		}
 		pipelines = pipelines.Add(config.PipelineConfig{
 			Name:      name,
 			PublishTo: config.DefaultPublishingSubject,
-			Events:    []string{"ADDED", "MODIFIED", "DELETED"},
+			Events:    []string{string(broker.Add), string(broker.Update), string(broker.Delete)},
 		})
 	case watch.Deleted:
+		if !pipelines.Contains(name) {
+			return false, nil
+		}
 		pipelines = pipelines.Delete(config.PipelineConfig{Name: name})
+	default:
+		// MODIFIED, BOOKMARK, ERROR: the watched-resource set is unchanged, so
+		// there is nothing to persist and no reason to resync.
+		return false, nil
 	}
 
 	existing[config.GlobalResourceKey] = pipelines
-	return h.Config.SetObject(config.ResourcesKey, existing)
+	if err := h.Config.SetObject(config.ResourcesKey, existing); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // TODO: move this to meshkit

--- a/meshsync/handlers_test.go
+++ b/meshsync/handlers_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/meshery/meshsync/internal/channels"
 	"github.com/meshery/meshsync/internal/config"
 	"github.com/meshery/meshsync/pkg/model"
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -195,11 +194,16 @@ func TestUpdatePipelineConfigRegistersBrokerEvents(t *testing.T) {
 	}
 }
 
+// logInfoLevel is MeshKit's info log level. logger.Options.LogLevel is a plain
+// int mirroring logrus severity levels (info == 4); it is spelled out here so
+// the tests depend only on MeshKit for logging, not on logrus directly.
+const logInfoLevel = 4
+
 func testLogger(t *testing.T) logger.Handler {
 	t.Helper()
 	log, err := logger.New("meshsync-test", logger.Options{
 		Format:   logger.SyslogLogFormat,
-		LogLevel: int(logrus.InfoLevel),
+		LogLevel: logInfoLevel,
 	})
 	if err != nil {
 		t.Fatalf("failed to create logger: %v", err)

--- a/meshsync/handlers_test.go
+++ b/meshsync/handlers_test.go
@@ -3,8 +3,17 @@ package meshsync
 import (
 	"reflect"
 	"testing"
+	"time"
 
+	configprovider "github.com/meshery/meshkit/config/provider"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/meshsync/internal/channels"
+	"github.com/meshery/meshsync/internal/config"
 	"github.com/meshery/meshsync/pkg/model"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 // TestSplitIntoMultipleSlices tests the splitIntoMultipleSlices function
@@ -48,5 +57,269 @@ func TestSplitIntoMultipleSlices(t *testing.T) {
 				t.Errorf("expected %v, but got %v", tc.expectedOutput, output)
 			}
 		})
+	}
+}
+
+func newConfigTestHandler(t *testing.T, seed config.PipelineConfigs) *Handler {
+	t.Helper()
+	cfg, err := configprovider.NewInMem(configprovider.Options{})
+	if err != nil {
+		t.Fatalf("failed to create in-mem config: %v", err)
+	}
+	if err := cfg.SetObject(config.ResourcesKey, map[string]config.PipelineConfigs{
+		config.GlobalResourceKey: seed,
+	}); err != nil {
+		t.Fatalf("failed to seed resources: %v", err)
+	}
+	return &Handler{Config: cfg}
+}
+
+func globalPipelines(t *testing.T, h *Handler) config.PipelineConfigs {
+	t.Helper()
+	existing := make(map[string]config.PipelineConfigs)
+	if err := h.Config.GetObject(config.ResourcesKey, &existing); err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	return existing[config.GlobalResourceKey]
+}
+
+// Shared fixtures for the CRD-watch tests. The values mirror a cert-manager CRD -
+// the controller whose continuous MODIFIED events motivated the resync fix.
+const (
+	testCRDGroup    = "cert-manager.io"
+	testCRDVersion  = "v1"
+	testCRDPlural   = "certificates"
+	testCRDPipeline = "certificates.v1.cert-manager.io" // resource.version.group
+)
+
+// crdPipelineEvents mirrors the broker event set updatePipelineConfig registers
+// for a discovered CRD (broker.Add/Update/Delete), pinned as literals so the
+// tests fail if that wire contract ever drifts.
+var crdPipelineEvents = []string{"ADDED", "MODIFIED", "DELETED"}
+
+func testCRDGVR() *schema.GroupVersionResource {
+	return &schema.GroupVersionResource{Group: testCRDGroup, Version: testCRDVersion, Resource: testCRDPlural}
+}
+
+// TestUpdatePipelineConfig verifies that a CRD watch event is only reported as a
+// config change (and therefore only triggers an informer resync) when it
+// actually mutates the set of watched resources. In particular MODIFIED events -
+// which controllers like cert-manager's cainjector emit continuously - must be
+// no-ops.
+func TestUpdatePipelineConfig(t *testing.T) {
+	gvr := testCRDGVR()
+	existingSeed := func() config.PipelineConfigs {
+		return config.PipelineConfigs{{
+			Name:      testCRDPipeline,
+			PublishTo: config.DefaultPublishingSubject,
+			Events:    crdPipelineEvents,
+		}}
+	}
+
+	tests := []struct {
+		name        string
+		seed        config.PipelineConfigs
+		eventType   watch.EventType
+		wantChanged bool
+		wantLen     int
+	}{
+		{"added new resource registers it", config.PipelineConfigs{}, watch.Added, true, 1},
+		{"added already-watched resource is a no-op", existingSeed(), watch.Added, false, 1},
+		{"deleted watched resource removes it", existingSeed(), watch.Deleted, true, 0},
+		{"deleted unwatched resource is a no-op", config.PipelineConfigs{}, watch.Deleted, false, 0},
+		{"modified watched resource never resyncs", existingSeed(), watch.Modified, false, 1},
+		{"modified unwatched resource never registers", config.PipelineConfigs{}, watch.Modified, false, 0},
+		{"bookmark never changes config", existingSeed(), watch.Bookmark, false, 1},
+		{"error never changes config", existingSeed(), watch.Error, false, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newConfigTestHandler(t, tc.seed)
+			changed, err := h.updatePipelineConfig(tc.eventType, gvr)
+			if err != nil {
+				t.Fatalf("updatePipelineConfig returned error: %v", err)
+			}
+			if changed != tc.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tc.wantChanged)
+			}
+			if got := globalPipelines(t, h); len(got) != tc.wantLen {
+				t.Errorf("global pipelines len = %d, want %d (%v)", len(got), tc.wantLen, got)
+			}
+		})
+	}
+}
+
+// TestUpdatePipelineConfigIdempotentAdd guards against duplicate pipeline
+// configs: a re-established CRD watch re-lists every existing CRD as ADDED, and
+// registering unconditionally would both double-publish resources and force a
+// needless resync each time.
+func TestUpdatePipelineConfigIdempotentAdd(t *testing.T) {
+	gvr := testCRDGVR()
+	h := newConfigTestHandler(t, config.PipelineConfigs{})
+
+	changed, err := h.updatePipelineConfig(watch.Added, gvr)
+	if err != nil || !changed {
+		t.Fatalf("first Added: changed=%v err=%v, want changed=true, err=nil", changed, err)
+	}
+
+	changed, err = h.updatePipelineConfig(watch.Added, gvr)
+	if err != nil {
+		t.Fatalf("second Added returned error: %v", err)
+	}
+	if changed {
+		t.Error("second Added reported changed=true; a re-listed CRD must be a no-op")
+	}
+	if got := globalPipelines(t, h); len(got) != 1 {
+		t.Errorf("expected exactly 1 pipeline config after duplicate ADD, got %d: %v", len(got), got)
+	}
+}
+
+// TestUpdatePipelineConfigRegistersBrokerEvents locks the wire contract: a newly
+// discovered CRD must be registered with exactly the broker event strings the
+// pipeline filters on, so publishing is not silently dropped if the broker
+// EventType values ever drift.
+func TestUpdatePipelineConfigRegistersBrokerEvents(t *testing.T) {
+	gvr := testCRDGVR()
+	h := newConfigTestHandler(t, config.PipelineConfigs{})
+
+	if _, err := h.updatePipelineConfig(watch.Added, gvr); err != nil {
+		t.Fatalf("updatePipelineConfig: %v", err)
+	}
+	got := globalPipelines(t, h)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 registered pipeline, got %d: %v", len(got), got)
+	}
+	if !reflect.DeepEqual(got[0].Events, crdPipelineEvents) {
+		t.Errorf("registered events = %v, want %v", got[0].Events, crdPipelineEvents)
+	}
+}
+
+func testLogger(t *testing.T) logger.Handler {
+	t.Helper()
+	log, err := logger.New("meshsync-test", logger.Options{
+		Format:   logger.SyslogLogFormat,
+		LogLevel: int(logrus.InfoLevel),
+	})
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	return log
+}
+
+// crdEvent builds a CustomResourceDefinition watch event equivalent to what the
+// API server streams, so it exercises the real parseCRDEvent/GVR-extraction path.
+func crdEvent(eventType watch.EventType, group, plural, version string) watch.Event {
+	return watch.Event{
+		Type: eventType,
+		Object: &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata":   map[string]interface{}{"name": plural + "." + group},
+			"spec": map[string]interface{}{
+				"group":    group,
+				"names":    map[string]interface{}{"plural": plural},
+				"versions": []interface{}{map[string]interface{}{"name": version}},
+			},
+		}},
+	}
+}
+
+// resyncSignaled runs handleCRDEvent and reports whether it requested an informer
+// resync (a blocking send on the ReSync channel).
+func resyncSignaled(t *testing.T, h *Handler, event watch.Event) bool {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		h.handleCRDEvent(event)
+		close(done)
+	}()
+
+	resyncCh := h.channelPool[channels.ReSync].(channels.ReSyncChannel)
+	select {
+	case <-resyncCh:
+		<-done // let the (now unblocked) ReSyncInformer send return
+		return true
+	case <-done:
+		return false
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleCRDEvent did not complete in time")
+		return false
+	}
+}
+
+// TestHandleCRDEventResync is an end-to-end check of the resync trigger. It is
+// the regression guard for the cert-manager re-list storm: a MODIFIED CRD event
+// must not tear down and rebuild every informer, while a genuinely new CRD still
+// must.
+func TestHandleCRDEventResync(t *testing.T) {
+	watched := config.PipelineConfigs{{
+		Name:      testCRDPipeline,
+		PublishTo: config.DefaultPublishingSubject,
+		Events:    crdPipelineEvents,
+	}}
+
+	tests := []struct {
+		name       string
+		seed       config.PipelineConfigs
+		event      watch.Event
+		wantResync bool
+	}{
+		{
+			name:       "modified watched crd does not resync",
+			seed:       watched,
+			event:      crdEvent(watch.Modified, testCRDGroup, testCRDPlural, testCRDVersion),
+			wantResync: false,
+		},
+		{
+			name:       "re-listed added crd does not resync",
+			seed:       watched,
+			event:      crdEvent(watch.Added, testCRDGroup, testCRDPlural, testCRDVersion),
+			wantResync: false,
+		},
+		{
+			name:       "newly added crd resyncs",
+			seed:       config.PipelineConfigs{},
+			event:      crdEvent(watch.Added, testCRDGroup, testCRDPlural, testCRDVersion),
+			wantResync: true,
+		},
+		{
+			name:       "deleted watched crd resyncs",
+			seed:       watched,
+			event:      crdEvent(watch.Deleted, testCRDGroup, testCRDPlural, testCRDVersion),
+			wantResync: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newConfigTestHandler(t, tc.seed)
+			h.Log = testLogger(t)
+			h.channelPool = map[string]channels.GenericChannel{
+				channels.ReSync: channels.NewReSyncChannel(),
+			}
+			if got := resyncSignaled(t, h, tc.event); got != tc.wantResync {
+				t.Errorf("resync signaled = %v, want %v", got, tc.wantResync)
+			}
+		})
+	}
+}
+
+// TestJitterBounds checks the backoff jitter stays within [d/2, d] so retries
+// are neither instantaneous nor longer than the intended backoff.
+func TestJitterBounds(t *testing.T) {
+	for _, d := range []time.Duration{2 * time.Second, 30 * time.Second, 2 * time.Minute} {
+		for i := 0; i < 1000; i++ {
+			j := jitter(d)
+			if j < d/2 || j > d {
+				t.Fatalf("jitter(%s) = %s, want within [%s, %s]", d, j, d/2, d)
+			}
+		}
+	}
+	if j := jitter(0); j != 0 {
+		t.Errorf("jitter(0) = %s, want 0", j)
+	}
+	if j := jitter(-time.Second); j != 0 {
+		t.Errorf("jitter(negative) = %s, want 0", j)
 	}
 }


### PR DESCRIPTION
## Summary

MeshSync triggered a full informer teardown-and-rebuild after **every** CRD watch event, including `MODIFIED`. On clusters running controllers that rewrite CRDs continuously - notably cert-manager's cainjector, which keeps updating `spec.conversion.webhook.clientConfig.caBundle` - this produced a recurring cluster-wide re-list storm. This PR resyncs only when the set of watched resources actually changes.

**Symptom** - Every CRD `MODIFIED` event (re)listed all ~66 watched resource types across the whole cluster.

**Root cause** - `handleCRDEvent` always called `ReSyncInformer()` after `updatePipelineConfig`. `updatePipelineConfig` only acts on `Added`/`Deleted` but returned only an `error`, so the caller could not tell a no-op `MODIFIED` from a real change. The resync path (`Run` -> debounced `debouncedRestartDiscovery` -> `UpdateInformer`) shuts down the entire `DynamicSharedInformerFactory` and rebuilds it. The GVR MeshSync derives from a CRD is `group/version/plural` (meshkit `GetGVRForCustomResources` reads `Versions[0].Name`), none of which a `caBundle` rewrite changes - so the resync accomplished nothing and re-listed everything.

**Fix** - Report whether the pipeline actually changed and resync only then.

## What changed

- **`updatePipelineConfig` now returns `(changed bool, error)`**; [`handleCRDEvent`](meshsync/handlers.go) resyncs only when `changed` is true. `MODIFIED`, `BOOKMARK`, and `ERROR` events are no-ops (no config write, no resync).
- **Idempotent `Added` / precise `Deleted`** via a new `PipelineConfigs.Contains`. This also fixes a **sibling bug**: a re-established CRD watch re-lists every existing CRD as `ADDED`, and the previous unconditional append accumulated duplicate pipeline configs - which register duplicate informer event handlers and **double-publish** every resource. `Deleted` is likewise a no-op when the resource is not watched.
- **Exponential backoff with jitter** in `WatchCRDs` (previously a flat 2s retry). `watchCRDsIteration` now returns an `error` so genuine watch failures / immediate collapses back off (2s -> 2m, jittered), while a healthy watch that the API server cycles normally resets to the flat 2s - so routine re-establishment is not penalized.
- Registered event set is now built from `broker.Add/Update/Delete` instead of magic strings (their source of truth).

## Deliberately deferred - incremental informer registration

The fix direction also suggested registering a single new informer for an added GVR instead of rebuilding the whole factory. I did **not** do that here, on purpose: after this change, a resync only fires on a *genuine* (and debounce-coalesced) CRD add/delete, so a full rebuild on those rare events is no longer a hot path. Doing it safely is a real refactor - `DynamicSharedInformerFactory` cannot stop a single informer (`Shutdown()` stops all), and keeping informers alive across changes introduces cross-goroutine mutation of `h.informer`/`h.stores` that today is unsynchronized - and it needs its own cluster validation. Happy to take it on as a follow-up PR.

## Out of scope / flagged

- **Separate confirmed bug (being addressed in its own change):** blacklist-mode discovery appears to publish nothing - `DefaultEvents = ["ADD","UPDATE","DELETE"]` (`internal/config/default_config.go`) never matches the broker's `"ADDED"/"MODIFIED"/"DELETED"` in the pipeline event filter (`internal/pipeline/handlers.go`). Different subsystem with deployment-wide blast radius, so not bundled here.
- **Pre-existing lint debt:** `golangci-lint` (full module) is already red on `master` with 10 `goconst` findings in `default_config.go`/`config_local.go`/`crd_config_test.go` - all files this PR does not touch. The changed files (`meshsync/...`, `internal/config/types*.go`) are lint-clean.

## Testing

Unit tests (all pass under `-race`, `golangci-lint` clean on changed packages):
- `TestUpdatePipelineConfig` - every event type x watched/unwatched state, asserting `changed` and resulting config length.
- `TestUpdatePipelineConfigIdempotentAdd` - duplicate `ADDED` neither grows config nor resyncs.
- `TestUpdatePipelineConfigRegistersBrokerEvents` - locks the `broker.*` -> wire-string contract.
- `TestHandleCRDEventResync` - end-to-end through `handleCRDEvent`: `MODIFIED` and re-listed `ADDED` do not signal resync; genuine add/delete do.
- `TestJitterBounds`, `TestPipelineConfigsContains`.

## Runtime verification

Ran the built binary in file-output mode against a local `docker-desktop`/kind cluster (v1.36.1) with the meshery CRDs + `meshery-meshsync` CR installed (per `integration-tests/infrastructure/setup.sh`), `DEBUG=true`, driving real `kubectl` CRD events:

- Fired 5 `MODIFIED` events on an existing CRD (the cainjector mechanism) -> **5 skips, 0 resyncs, 0 factory rebuilds**:
  ```
  crd MODIFIED event for meshery.io/v1alpha1, Resource=brokers did not change discovery config; skipping informer resync  (x5)
  ```
- Added a new CRD -> exactly **1** resync + **1** factory rebuild; the trailing `MODIFIED` events Kubernetes emits while populating CRD status were **skipped** (old code would have rebuilt twice more).
- Deleted it -> **1** resync + **1** rebuild; finalization `MODIFIED`s skipped.
- Final counts reconciled exactly (resync-triggers 4, factory-rebuilds 3, modified-skips 9); no errors or panics; 427 resources discovered end-to-end.

The idempotent re-list path and the backoff path were not driven at runtime (they need a watch close / API-server failure) and are covered by unit tests; the re-list case shares the exact `changed==false` skip path exercised via `MODIFIED`.
