### PR TITLE
[config] Fix blacklist-mode discovery silently dropping all broker events

### DIFF
--- a/internal/config/crd_config_test.go
+++ b/internal/config/crd_config_test.go
@@ -175,3 +175,27 @@ func TestBlackListResourcesUseBrokerEvents(t *testing.T) {
 		t.Fatal("expected blacklist config to produce pipelines, got none")
 	}
 }
+
+// TestDefaultPipelinesCarryDefaultEvents verifies the init() backfill: the
+// default pipeline templates are seeded directly as runtime config when no CRD
+// config is available (e.g. a CRD read error), so every template must carry a
+// non-empty, broker-matching event set or discovery would silently drop
+// everything on that fallback path.
+func TestDefaultPipelinesCarryDefaultEvents(t *testing.T) {
+	sawPipeline := false
+	for key, pipelines := range Pipelines {
+		for _, p := range pipelines {
+			sawPipeline = true
+			if len(p.Events) == 0 {
+				t.Errorf("default pipeline %q in %q has empty Events", p.Name, key)
+				continue
+			}
+			if !reflect.DeepEqual(p.Events, DefaultEvents) {
+				t.Errorf("default pipeline %q in %q has Events %v, want %v", p.Name, key, p.Events, DefaultEvents)
+			}
+		}
+	}
+	if !sawPipeline {
+		t.Fatal("expected default Pipelines to be non-empty")
+	}
+}

--- a/internal/config/crd_config_test.go
+++ b/internal/config/crd_config_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/meshery/meshkit/broker"
+	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -112,5 +114,64 @@ func TestBlackListResources(t *testing.T) {
 
 	if len(meshsyncConfig.Pipelines["local"]) != expectedLocalCount {
 		t.Errorf("local pipelines not well configured expected %d", expectedLocalCount)
+	}
+}
+
+// TestDefaultEventsMatchBrokerWireTypes pins DefaultEvents to the broker's wire
+// event types. publishItem gates every event on
+// slices.Contains(config.Events, string(evtype)) where evtype is one of
+// broker.Add/Update/Delete, so any drift here silently drops events for every
+// pipeline that inherits DefaultEvents (the blacklist path and the default
+// pipelines).
+func TestDefaultEventsMatchBrokerWireTypes(t *testing.T) {
+	want := []string{string(broker.Add), string(broker.Update), string(broker.Delete)}
+	if !reflect.DeepEqual(DefaultEvents, want) {
+		t.Fatalf("DefaultEvents = %v, want broker wire types %v", DefaultEvents, want)
+	}
+
+	// Assert the concrete wire values too, so a rename of the broker constants
+	// that changed their string values would fail loudly here rather than
+	// silently breaking discovery.
+	if !reflect.DeepEqual(DefaultEvents, []string{"ADDED", "MODIFIED", "DELETED"}) {
+		t.Fatalf("DefaultEvents = %v, want [ADDED MODIFIED DELETED]", DefaultEvents)
+	}
+}
+
+// TestBlackListResourcesUseBrokerEvents is the regression test for the
+// blacklist silent-drop bug: filterBlacklistedPipelines stamps DefaultEvents
+// onto every blacklist-derived pipeline, and those events must be the broker
+// wire types or publishItem drops the resource entirely.
+func TestBlackListResourcesUseBrokerEvents(t *testing.T) {
+	watchList := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "watch-list", Namespace: "default"},
+		Data: map[string]string{
+			"blacklist": `["namespaces.v1."]`,
+			"whitelist": "",
+		},
+	}
+
+	meshsyncConfig, err := PopulateConfigs(watchList)
+	if err != nil {
+		t.Fatalf("PopulateConfigs returned error: %v", err)
+	}
+
+	wantEvents := []string{string(broker.Add), string(broker.Update), string(broker.Delete)}
+	sawPipeline := false
+	for key, pipelines := range meshsyncConfig.Pipelines {
+		for _, p := range pipelines {
+			sawPipeline = true
+			if !reflect.DeepEqual(p.Events, wantEvents) {
+				t.Errorf("blacklist pipeline %q in %q has Events %v, want %v", p.Name, key, p.Events, wantEvents)
+			}
+			// Guard against a regression to the old, never-matching literals.
+			for _, bad := range []string{"ADD", "UPDATE", "DELETE"} {
+				if slices.Contains(p.Events, bad) {
+					t.Errorf("blacklist pipeline %q uses non-broker event %q: %v", p.Name, bad, p.Events)
+				}
+			}
+		}
+	}
+	if !sawPipeline {
+		t.Fatal("expected blacklist config to produce pipelines, got none")
 	}
 }

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"time"
+
+	"github.com/meshery/meshkit/broker"
 )
 
 var (
@@ -385,5 +387,13 @@ var (
 		},
 	}
 
-	DefaultEvents = []string{"ADD", "UPDATE", "DELETE"}
+	// DefaultEvents is the canonical set of event types the default and
+	// blacklist-configured pipelines watch. These MUST be the broker wire values
+	// (broker.Add == "ADDED", broker.Update == "MODIFIED", broker.Delete ==
+	// "DELETED") because publishItem compares them verbatim against the event
+	// type the broker delivers - `slices.Contains(config.Events, string(evtype))`.
+	// The earlier "ADD"/"UPDATE"/"DELETE" literals never matched, so every event
+	// was silently dropped for pipelines configured via the blacklist path.
+	// Sourcing them from the broker constants keeps them from drifting again.
+	DefaultEvents = []string{string(broker.Add), string(broker.Update), string(broker.Delete)}
 )

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -397,3 +397,22 @@ var (
 	// Sourcing them from the broker constants keeps them from drifting again.
 	DefaultEvents = []string{string(broker.Add), string(broker.Update), string(broker.Delete)}
 )
+
+func init() {
+	// The pipeline templates above deliberately omit per-resource Events: the
+	// whitelist path fills them from user config and the blacklist path fills
+	// them with DefaultEvents. But these same templates are also seeded directly
+	// as the runtime config when no meshsync CRD config is available - for
+	// example when a CRD read/parse error leaves crdConfigs nil (see
+	// pkg/lib/meshsync). With an empty Events set, publishItem's
+	// slices.Contains(Events, string(evtype)) never matches and discovery
+	// silently produces nothing. Backfill the canonical default so the default
+	// pipelines are safe to use standalone.
+	for _, pipelines := range Pipelines {
+		for i := range pipelines {
+			if len(pipelines[i].Events) == 0 {
+				pipelines[i].Events = DefaultEvents
+			}
+		}
+	}
+}

--- a/meshsync/handlers.go
+++ b/meshsync/handlers.go
@@ -433,7 +433,9 @@ func (h *Handler) updatePipelineConfig(
 		pipelines = pipelines.Add(config.PipelineConfig{
 			Name:      name,
 			PublishTo: config.DefaultPublishingSubject,
-			Events:    []string{"ADDED", "MODIFIED", "DELETED"},
+			// Dynamically discovered CRD pipelines watch the canonical default
+			// event set; keep them sourced from one place to avoid drift.
+			Events: config.DefaultEvents,
 		})
 	case watch.Deleted:
 		pipelines = pipelines.Delete(config.PipelineConfig{Name: name})

--- a/pkg/lib/meshsync/meshsync.go
+++ b/pkg/lib/meshsync/meshsync.go
@@ -85,9 +85,15 @@ func Run(log logger.Handler, optsSetters ...OptionsSetter) error {
 
 	// pass configs from crd to default configs
 	if crdConfigs != nil {
-		if len(crdConfigs.Pipelines) > 0 {
-			config.Pipelines = crdConfigs.Pipelines
-		}
+		// Assign the CRD-derived pipelines whenever a config was produced, even
+		// if the watch-list filtered down to zero pipelines: an explicit
+		// whitelist/blacklist that matches nothing means "watch nothing" and must
+		// not silently fall back to the full default set. The default pipelines
+		// apply only when there was no CRD config at all (crdConfigs == nil), e.g.
+		// a CRD read/parse error; in that case config.Pipelines keeps its package
+		// default, whose Events are backfilled in config's init() so it still
+		// publishes rather than silently dropping everything.
+		config.Pipelines = crdConfigs.Pipelines
 
 		if len(crdConfigs.Listeners) > 0 {
 			config.Listeners = crdConfigs.Listeners


### PR DESCRIPTION
**Description**

This PR fixes a silent-drop bug in **blacklist-mode discovery**: pipelines configured via the blacklist path published **no** resources to the broker, because their event-filter strings could never match the broker's event-type strings.

**Symptom** - a MeshSync CR whose `watch-list` uses a `blacklist` (no `whitelist`) discovers resources but publishes nothing for `ADDED`/`MODIFIED`/`DELETED`.

**Root cause** - `filterBlacklistedPipelines` stamps `DefaultEvents` onto every blacklist-derived pipeline, but `DefaultEvents` was `["ADD","UPDATE","DELETE"]`. The only consumer, `publishItem`, gates each event on `slices.Contains(config.Events, string(evtype))`, where `evtype` is the broker wire value `broker.Add`/`broker.Update`/`broker.Delete` = `"ADDED"`/`"MODIFIED"`/`"DELETED"`. The strings never matched, so every event was skipped. The whitelist path was unaffected (it uses user-supplied `Events`; the local default whitelist already used the wire values).

**Fix** - source `DefaultEvents` from `broker.Add/Update/Delete` so it carries the wire values and cannot drift from the constants again.

While tracing the seed path I found and fixed an adjacent latent bug in the same area (second commit, kept separate so it can be reviewed/reverted independently):

**Symptom** - a transient CRD read/parse error makes MeshSync publish *nothing at all*.

**Root cause** - the hardcoded default `Pipelines` templates carry an **empty** `Events` slice. On the fallback path in `pkg/lib/meshsync`, when `crdConfigs == nil` those templates are seeded **directly** as the runtime config, so `slices.Contains([], "ADDED")` drops everything - one CRD error silently disables all discovery.

**Fix** - backfill each template's empty `Events` with `DefaultEvents` in `init()`, and change the seed guard so an explicit CRD config is respected even when it filters to zero pipelines (defaults now apply only when there was no CRD config at all). See the reviewer note below for the resulting behavior change.

**Changes**
- `internal/config/default_config.go` - `DefaultEvents` sourced from `broker.Add/Update/Delete`; `init()` backfills the default pipeline templates' empty `Events`.
- `meshsync/handlers.go` - `updatePipelineConfig` now uses `config.DefaultEvents` instead of a duplicated `["ADDED","MODIFIED","DELETED"]` literal (single source of truth).
- `pkg/lib/meshsync/meshsync.go` - seed `config.Pipelines` from the CRD config whenever one was produced (even if empty), so a watch-list that matches nothing means "watch nothing" rather than silently falling back to the full default set.
- `internal/config/crd_config_test.go` - three regression tests (below).

**Notes for Reviewers**

- **Message-volume blast radius (please verify before rollout).** If blacklist mode has been silently dropping events in your environment, merging this will *start* publishing all non-blacklisted resource events to the broker/NATS. Confirm volume expectations. This is deliberately its own PR, separate from the informer-resync efficiency change where the bug was discovered.
- **Behavior change from the second commit.** With the templates backfilled, the direct-seed path now publishes. The seed guard changed from `len(crdConfigs.Pipelines) > 0` to assigning whenever `crdConfigs != nil`, so:
  - CRD read/parse error (`crdConfigs == nil`): now publishes the default pipeline set instead of nothing (degraded-but-functional).
  - A valid watch-list that filters to zero pipelines (e.g. a whitelist matching no known resource, or a blacklist excluding all): still publishes nothing (unchanged net behavior), and no longer risks leaking the full default set.
- **Test placement.** Tests live in `internal/config/crd_config_test.go`, where the bug lives (`DefaultEvents` + `filterBlacklistedPipelines`). Each fails without its fix:
  - `TestDefaultEventsMatchBrokerWireTypes` - pins `DefaultEvents` to the broker wire contract.
  - `TestBlackListResourcesUseBrokerEvents` - blacklist pipelines must carry broker events, never the old literals.
  - `TestDefaultPipelinesCarryDefaultEvents` - every default template carries a non-empty, broker-matching event set.
- **Recurrence check.** `PipelineConfig.Events` has a single consumer (`publishItem`); all four feeder paths (blacklist, whitelist, default templates, dynamic CRD) now supply broker-matching events. `config_local.go` already used the wire values. `ListenerConfig.Events` is a dead field (no consumer) and was left untouched to keep scope tight.
- **Verification still needing a cluster:** deploy with a blacklist-style meshsync CR and confirm resources are published for `ADDED`/`MODIFIED`/`DELETED`. `go build ./...`, `go vet ./...`, and `go test ./...` all pass locally.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
