### PR TITLE
chore(skills): add verifier-meshsync runtime-verification skill

### DIFF
--- a/.claude/skills/verifier-meshsync/SKILL.md
+++ b/.claude/skills/verifier-meshsync/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: verifier-meshsync
+description: Runtime-verify a MeshSync change by running the agent against a local Kubernetes cluster and observing its behavior in the debug log and file output. Use this whenever verifying, testing, or confirming a MeshSync code change actually works at runtime - CRD watching and informer resync, resource discovery/publishing, filtering (namespaces/resources), whitelist/blacklist config, backoff/reconnect - and whenever /verify runs on the meshsync repo. Reach for it instead of a cold start any time you need to see MeshSync's discovery pipeline actually execute against a cluster, not just pass tests.
+---
+
+# Verifying MeshSync at runtime
+
+MeshSync is a Kubernetes agent: it watches the cluster with dynamic informers and
+publishes resource events to a NATS broker (or to a file). **The surface is the
+running agent against a real cluster** - a change is verified by making the
+changed code path execute and reading what the agent logs and writes, not by
+running its unit tests (CI does that).
+
+The whole game is: get the agent running against a local cluster, drive the
+cluster so the changed code path fires, and read the evidence out of the debug
+log. This skill encodes the parts that are fiddly to rediscover each time.
+
+## Quick start
+
+```bash
+SKILL=.claude/skills/verifier-meshsync/scripts/verify-env.sh
+$SKILL up      # pin an isolated kubeconfig to a reachable local cluster + install CRD/CR
+$SKILL run     # build the binary and launch it in file mode with DEBUG logging
+sleep 10       # let it connect and finish initial discovery
+tail -f "$($SKILL logs)"   # watch it; drive events in another shell (see below)
+$SKILL down    # stop meshsync, remove the CRD/CR/namespace it added
+```
+
+`verify-env.sh` only automates the deterministic setup. **Driving the surface and
+choosing what to observe is your job** - it depends on what changed.
+
+## Why each setup step matters
+
+Read these before trusting the harness; they are the non-obvious traps.
+
+- **Don't trust the default kubeconfig context.** In practice it often points at
+  an unreachable remote cluster, and `mesherykube.New(nil)` will silently try to
+  use it. `up` probes local contexts (docker-desktop, minikube, kind, orbstack,
+  ...) for `/readyz` and writes a *minified, isolated* kubeconfig so the binary
+  cannot wander off. Pass `MESHSYNC_VERIFY_CONTEXT=<name>` to force one.
+- **`WatchCRDs` only runs when the MeshSync CR is present.** `useCRDFlag` (in
+  `pkg/lib/meshsync/meshsync.go`) is true only when the `meshsyncs.meshery.io`
+  CRD *and* the `meshery-meshsync` CR (namespace `meshery`) exist. Without them
+  the CRD-watch goroutine never starts and you will "verify" nothing. `up`
+  installs both (meshery-operator CRDs + `integration-tests/infrastructure/meshsync.yaml`).
+- **Use file output mode, not broker mode.** `--output file` runs the full
+  discovery pipeline (informers, `WatchCRDs`, `Run`) without needing a NATS
+  broker. `ListenToRequests` is the only broker-only goroutine, and you rarely
+  need it. The written snapshot doubles as proof discovery worked end-to-end.
+- **`DEBUG=true` is required** to see the discovery/resync debug lines (see
+  `main.go`: it maps `DEBUG=true|1` to logrus debug level).
+
+## Drive the surface
+
+Pick the smallest cluster action that makes the changed code run. Examples:
+
+| Changed area | Drive it with |
+|---|---|
+| CRD watch / informer resync (`handleCRDEvent`, `updatePipelineConfig`) | `kubectl annotate crd <name> k=v$RANDOM --overwrite` (MODIFIED); `kubectl apply`/`delete` a dummy CRD (ADDED/DELETED) |
+| Resource discovery / publishing | create/patch/delete a watched resource (`kubectl create deploy`, `kubectl label`, ...) |
+| Namespace/resource filtering (`--outputNamespaces`, `--outputResources`) | launch with the flag, create resources in/out of scope, check they are/aren't in the snapshot |
+| whitelist/blacklist config | edit the CR's `watch-list`, restart the binary, check which kinds appear |
+
+For a MODIFIED burst use a *changing* annotation value each time (a repeated
+identical value is a no-op and emits no watch event).
+
+## Observe: signal lines
+
+Grep the log for the lines that mark the behavior. These are current as of this
+writing - **grep the source to confirm they still exist** before relying on them,
+since log strings drift:
+
+| Signal | Log substring | Source |
+|---|---|---|
+| A resync was requested for a CRD event | `Resyncing informer from watch crd` | `meshsync/handlers.go` `handleCRDEvent` |
+| A CRD event was correctly ignored | `did not change discovery config; skipping informer resync` | `meshsync/handlers.go` `handleCRDEvent` |
+| The informer factory was torn down/rebuilt | `Creating new dynamic shared informer factory` | `meshsync/handlers.go` `UpdateInformer` |
+| A resource event was published | `Received ADD event for` / `UPDATE` / `DELETE` | `internal/pipeline/handlers.go` |
+| Watch re-established / backoff | `crdWatcher.ResultChan() was closed`, `watch iteration failed`, `watch collapsed` | `meshsync/handlers.go` `WatchCRDs` |
+
+Count them and reconcile against what you drove - a bare "it logged the right
+line" is weaker than "I drove N events and got exactly the N signals I expected,
+and the counts add up". Use a log mark so you only look at lines after an action:
+
+```bash
+LOG="$($SKILL logs)"; MARK=$(wc -l < "$LOG")
+# ... drive events, then wait past the 5s resync debounce ...
+tail -n +$((MARK+1)) "$LOG" | grep -E 'Resyncing informer|did not change discovery|dynamic shared informer factory' \
+  | sed -E 's/.*msg="//; s/".*//' | sort | uniq -c
+```
+
+Also sanity-check the whole run: `grep -iE 'level=error|panic:' "$LOG"`.
+
+## Reconcile and clean up
+
+Reconcile the totals so the picture is airtight, e.g. "resync-triggers = startup
+ADDs + my ADD + my DELETE; modified-skips = my MODIFIED burst + the trailing
+status/finalizer MODIFIEDs k8s emits on create/delete". Then `$SKILL down` and
+confirm the process is gone (`pgrep -f meshsync-bin`).
+
+## Worked example: the CRD re-list storm fix
+
+Verifying that CRD `MODIFIED` events no longer trigger a full informer resync
+(the cert-manager cainjector `caBundle` storm):
+
+1. `up` + `run`, wait ~10s. Startup lists existing CRDs as ADDED; genuinely new
+   ones (e.g. `brokers`, `meshsyncs`) each drive one resync, coalesced by the 5s
+   debounce into one `Creating new dynamic shared informer factory`.
+2. Fire 5 MODIFIED events: `for i in 1 2 3 4 5; do kubectl annotate crd brokers.meshery.io storm=$i-$RANDOM --overwrite; sleep 1; done`, wait 8s.
+   Expect **5x `did not change discovery config; skipping informer resync`, 0 resyncs, 0 rebuilds**.
+3. `kubectl apply` a dummy CRD -> **1 resync + 1 rebuild**; its trailing status
+   MODIFIEDs are **skipped**. `kubectl delete` it -> **1 resync + 1 rebuild**;
+   finalizer MODIFIEDs skipped.
+4. Confirm the snapshot has resources (`grep -c 'kind:' "$WORKDIR/snapshot.yaml"`)
+   and the log has no errors.
+
+Runtime-observable paths NOT covered by this harness: idempotent re-list on watch
+re-establishment and exponential backoff both need a watch close / API-server
+failure you can't force cheaply - lean on the unit tests for those and say so.
+
+## Report
+
+Follow the `/verify` report format: verdict, claim, method, numbered steps each
+with what you did to the running agent and what it logged, an evidence sample
+(the grepped signal lines), and findings. Never report PASS from tests or a clean
+build - only from the agent actually doing the thing at its surface.

--- a/.claude/skills/verifier-meshsync/scripts/verify-env.sh
+++ b/.claude/skills/verifier-meshsync/scripts/verify-env.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# verify-env.sh - stand up / launch / tear down a local MeshSync runtime for
+# verification. This scripts only the boring, deterministic parts (cluster
+# handle, CRD+CR bring-up, launch, cleanup) so the human/agent driving the
+# verification can focus on the behavior actually under test.
+#
+# Subcommands:
+#   up     Pin an isolated kubeconfig to a reachable LOCAL cluster and install
+#          the meshsync CRD + CR (required for WatchCRDs to run).
+#   run    Build the meshsync binary and launch it in file-output mode with
+#          DEBUG logging, backgrounded, logs captured.
+#   logs   Print the path to the running log (tail it yourself).
+#   down   Stop meshsync and remove everything 'up' created.
+#
+# State (kubeconfig, pid, log) lives in $WORKDIR so subcommands share it.
+#
+# Env overrides:
+#   WORKDIR                  scratch dir (default: ${TMPDIR:-/tmp}/meshsync-verify)
+#   MESHSYNC_VERIFY_CONTEXT  force a specific kube context instead of autodetect
+#   MESHERY_CRDS_URL         override the meshery-operator CRDs manifest URL
+
+set -euo pipefail
+
+WORKDIR="${WORKDIR:-${TMPDIR:-/tmp}/meshsync-verify}"
+KC="$WORKDIR/kubeconfig.yaml"
+PIDFILE="$WORKDIR/meshsync.pid"
+LOG="$WORKDIR/meshsync.log"
+SNAPSHOT="$WORKDIR/snapshot.yaml"
+MESHERY_CRDS_URL="${MESHERY_CRDS_URL:-https://raw.githubusercontent.com/meshery/meshery/refs/heads/master/install/kubernetes/helm/meshery-operator/crds/crds.yaml}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+mkdir -p "$WORKDIR"
+
+# Candidate local contexts, in preference order. The DEFAULT kubeconfig context
+# is deliberately NOT trusted - in practice it often points at an unreachable
+# remote cluster, and meshsync would silently try to use it.
+CANDIDATE_CONTEXTS=(docker-desktop orbstack rancher-desktop minikube kind-kind colima)
+
+reachable() { kubectl --context="$1" get --raw='/readyz' --request-timeout=6s >/dev/null 2>&1; }
+
+pick_context() {
+  if [[ -n "${MESHSYNC_VERIFY_CONTEXT:-}" ]]; then
+    reachable "$MESHSYNC_VERIFY_CONTEXT" || { echo "forced context '$MESHSYNC_VERIFY_CONTEXT' is not reachable" >&2; exit 1; }
+    echo "$MESHSYNC_VERIFY_CONTEXT"; return
+  fi
+  # Try known local names, then any context whose name contains kind/minikube.
+  local ctx
+  for ctx in "${CANDIDATE_CONTEXTS[@]}"; do
+    if kubectl config get-contexts -o name 2>/dev/null | grep -qx "$ctx" && reachable "$ctx"; then
+      echo "$ctx"; return
+    fi
+  done
+  while read -r ctx; do
+    if reachable "$ctx"; then echo "$ctx"; return; fi
+  done < <(kubectl config get-contexts -o name 2>/dev/null | grep -iE 'kind|minikube|desktop|orbstack|colima' || true)
+  echo "" ; return
+}
+
+cmd_up() {
+  local ctx; ctx="$(pick_context)"
+  if [[ -z "$ctx" ]]; then
+    echo "No reachable local cluster found." >&2
+    echo "Start one (e.g. Docker Desktop Kubernetes, minikube start), or run" >&2
+    echo "  $REPO_ROOT/integration-tests/infrastructure/setup.sh setup" >&2
+    echo "to create a dedicated kind cluster, then re-run: $0 up" >&2
+    exit 1
+  fi
+  echo "Using local context: $ctx"
+  kubectl config view --minify --context="$ctx" --raw > "$KC"
+  export KUBECONFIG="$KC"
+  echo "Pinned isolated kubeconfig -> $KC"
+
+  kubectl get ns meshery >/dev/null 2>&1 || kubectl create namespace meshery
+  # The MeshSync CRD (meshsyncs.meshery.io) gates useCRDFlag, which gates
+  # WatchCRDs. Without the CRD *and* the meshery-meshsync CR, WatchCRDs never
+  # starts and CRD-event handling can't be observed at all.
+  kubectl apply -f "$MESHERY_CRDS_URL"
+  kubectl apply -f "$REPO_ROOT/integration-tests/infrastructure/meshsync.yaml"
+  kubectl -n meshery get meshsync meshery-meshsync
+  echo "Cluster ready. Export KUBECONFIG=$KC for kubectl commands against it."
+}
+
+cmd_run() {
+  [[ -f "$KC" ]] || { echo "run '$0 up' first (no kubeconfig at $KC)" >&2; exit 1; }
+  echo "Building meshsync binary..."
+  ( cd "$REPO_ROOT" && go build -o "$WORKDIR/meshsync-bin" . )
+  : > "$LOG"
+  DEBUG=true KUBECONFIG="$KC" "$WORKDIR/meshsync-bin" \
+      --output file --outputFile "$SNAPSHOT" > "$LOG" 2>&1 &
+  echo "$!" > "$PIDFILE"
+  echo "meshsync PID $(cat "$PIDFILE"), log: $LOG, snapshot: $SNAPSHOT"
+  echo "Give it ~10s to connect and finish initial discovery before driving events."
+}
+
+cmd_logs() { echo "$LOG"; }
+
+cmd_down() {
+  [[ -f "$PIDFILE" ]] && kill "$(cat "$PIDFILE")" 2>/dev/null && echo "meshsync stopped" || true
+  rm -f "$PIDFILE"
+  if [[ -f "$KC" ]]; then
+    export KUBECONFIG="$KC"
+    kubectl delete -f "$REPO_ROOT/integration-tests/infrastructure/meshsync.yaml" >/dev/null 2>&1 || true
+    kubectl delete crd brokers.meshery.io meshsyncs.meshery.io >/dev/null 2>&1 || true
+    kubectl delete namespace meshery >/dev/null 2>&1 || true
+    echo "removed meshery CRDs, CR, and namespace"
+  fi
+}
+
+case "${1:-}" in
+  up)   cmd_up ;;
+  run)  cmd_run ;;
+  logs) cmd_logs ;;
+  down) cmd_down ;;
+  *)    echo "usage: $0 {up|run|logs|down}" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

Adds a repo-local `verifier-meshsync` skill under `.claude/skills/` that captures the repeatable recipe for verifying a MeshSync change **at runtime** - running the agent against a local Kubernetes cluster and observing its behavior - rather than trusting unit tests. The `/verify` workflow auto-discovers `verifier-*` skills in `.claude/skills/`, so this turns a ~15-minute cold start into a one-command setup for the next person (or agent) checking a MeshSync PR.

It was written from, and validated against, the runtime verification done for the CRD re-list-storm fix (informer resync only on real CRD add/delete).

## What's in it

- **`SKILL.md`** - the protocol and the non-obvious traps, with the *why* for each:
  - Get an isolated cluster handle. The default kubeconfig context often points at an unreachable remote; the skill probes local contexts for reachability and pins a minified, isolated kubeconfig so the binary can't wander off.
  - Bring up the `meshsyncs.meshery.io` CRD **and** the `meshery-meshsync` CR - `useCRDFlag` (which gates `WatchCRDs`) is false without them, so CRD-event behavior is otherwise unobservable.
  - Run in `--output file` + `DEBUG=true` (full discovery pipeline, no NATS needed; the snapshot doubles as proof discovery ran).
  - A **signal-line reference table** (which debug string marks which behavior, and its source location) with a caveat to re-grep source since log strings drift.
  - A drive-it table mapping changed areas (CRD resync, discovery, filtering, whitelist/blacklist, backoff) to the `kubectl` actions that exercise them, plus reconcile-and-clean-up guidance and the CRD-resync storm as a worked example.
- **`scripts/verify-env.sh`** - automates only the deterministic setup: `up` (pin kubeconfig + install CRD/CR), `run` (build + launch file/debug mode, backgrounded), `logs`, `down` (stop + remove everything it created).

## Validation

Ran the skill's own automation end-to-end against a `docker-desktop`/kind cluster: `up` autodetected the cluster and installed the CRD+CR, `run` built and launched the agent, 4 driven CRD `MODIFIED` events produced exactly 4 "skipping informer resync" log lines with 0 resyncs / 0 factory rebuilds and 425 resources discovered into the snapshot, and `down` restored the cluster clean.

## Notes

- The trigger description was run through a description-optimization loop (20 queries, 5 iterations). It held **100% precision** on tricky near-miss negatives (test-fixing, other-repo verification, ops debugging, code review, cluster-setup-only) but low recall on direct asks - verifier skills tend to undertrigger because the model figures it can "just run it." The loop selected the original description as best (no rewrite beat it on held-out data), which is fine in practice: the primary trigger path is `/verify`'s directory discovery, not description matching.
- Independent of the fix in #568; scoped to just the skill files.
