### PR TITLE
docs: add AGENTS.md / CLAUDE.md agent instructions with ecosystem-shared directives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# MeshSync
+
+> `CLAUDE.md` is a symlink to `AGENTS.md`; they are always identical. Edit `AGENTS.md`.
+
+MeshSync is Meshery's Kubernetes cluster-state synchronization agent: a Go controller (not a Kubebuilder operator) that watches a cluster with dynamic informers, converts every discovered resource into a canonical model, and publishes it to Meshery Server over NATS (or to a file). Meshery Operator deploys one MeshSync instance per managed cluster (see `meshery/meshery-operator`'s `MeshSync` CRD) and injects `BROKER_URL`.
+
+## Commands
+
+- `make build` - compile `main.go` to `bin/meshsync`
+- `make run` - start a local NATS container (`make nats-run`) then run MeshSync against it with `DEBUG=true`
+- `make test` - `lint-run` then `go test -failfast --short ./... -race`
+- `make lint-run` - `golangci-lint run ./...`
+- `make coverage-report` - unit tests with an HTML coverage report (`cover.html`)
+- `make integration-tests` - full kind + NATS docker-compose cycle (`integration-tests-setup` -> `integration-tests-run` -> `integration-tests-cleanup`); see [testing](docs/agent-instructions/testing.md) for sub-targets and single-test forms
+- Runtime verification against a live cluster (not just tests): use the `verifier-meshsync` skill (`.claude/skills/verifier-meshsync/`)
+
+## Critical Rules
+
+1. **MeshKit structured errors only.** Every error is a builder over `github.com/meshery/meshkit/errors` with a unique code constant (`^Err[A-Z].+Code$`) - never `fmt.Errorf`/`errors.New("...")`. Codes are allocated from `helpers/component_info.json`'s `next_error_code` and are unique per package `error.go` (`meshsync/error.go`, `internal/pipeline/error.go`, `internal/config/error.go`). `.github/workflows/error-codes-updater.yml` runs `meshkit/cmd/errorutil` on every push to `master` touching `**.go` and self-commits updated codes/exports - do not hand-allocate a code that utility would reassign. Full convention: [errors](docs/agent-instructions/errors.md).
+2. **Identifier naming - partial.** Unlike `meshery-cloud`, MeshSync's wire model (`pkg/model.KubernetesResource` and siblings) is a local Go/GORM struct, not sourced from `github.com/meshery/schemas`, and already mixes `camelCase` and `snake_case` JSON tags. New fields follow the ecosystem's camelCase-wire contract; do not silently recase existing fields. Full rule and the migration path if this model is ever moved into schemas: [naming conventions](docs/agent-instructions/naming-conventions.md).
+3. **Deployment coupling.** MeshSync's CLI flags, config schema (`internal/config`), and the `KubernetesResource` model are consumed by Meshery Operator (which deploys this binary) and Meshery Server (which consumes the broker stream). Coordinate flag/config/model changes with both repos; do not assume this repo alone defines the contract.
+4. **Pipeline stages are rebuilt per run.** `internal/pipeline.New` constructs fresh stages on every discovery and resync; never hoist stages or steps into shared package-level state - see [architecture](docs/agent-instructions/architecture.md).
+
+## Required on Every PR
+
+- **Tests accompany every behavioral change.** Run every locally-runnable test
+  before requesting review; never defer runnable coverage to reviewers or
+  follow-up PRs.
+- **Documentation accompanies every behavioral change, in both forms:**
+  - External, user-facing: docs.meshery.io (source: meshery/meshery docs) -
+    update whenever the change is user-visible.
+  - Internal, developer-facing: this repo's [`docs/`](docs/) - update whenever
+    architecture, workflows, or contracts change.
+- **Schema-aware changes**: MeshSync's wire model is not yet sourced from `meshery/schemas` (see [naming conventions](docs/agent-instructions/naming-conventions.md)); if a change migrates or aligns a field with the schemas contract, run `cd ../schemas && make validate-schemas && make consumer-audit` before pushing.
+- **Sign off every commit** (`git commit -s`).
+- **No AI attribution** in commits, PR descriptions, comments, or code.
+
+## Detailed Instructions
+
+- [Architecture](docs/agent-instructions/architecture.md) - discovery pipeline, output/dedup, channels, config, deployment topology
+- [Errors](docs/agent-instructions/errors.md) - MeshKit error convention and the errorutil workflow
+- [Naming conventions](docs/agent-instructions/naming-conventions.md) - the ecosystem identifier-casing contract and MeshSync's current divergence
+- [Testing](docs/agent-instructions/testing.md) - unit, integration, and runtime-verification commands
+
+## Further Reading
+
+- [design-spec: MeshSync infrastructure synchronization](docs/design-spec_meshsync-infrastructure-synchronization.md)
+- [design-spec: embedded MeshSync](docs/design-spec_embedded-meshsync.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/agent-instructions/architecture.md
+++ b/docs/agent-instructions/architecture.md
@@ -1,0 +1,69 @@
+# Architecture
+
+## Overview
+
+MeshSync is a standalone Go binary, one instance per managed Kubernetes cluster. It has no HTTP API and no persistent store of its own: it watches the API server via dynamic informers, converts each object into a canonical model, deduplicates, and publishes the result over NATS (default) or to a snapshot file.
+
+```
+main.go --parses CLI flags--> pkg/lib/meshsync.Run(...)
+                                      |
+                                      v
+                              meshsync.Handler (meshsync/meshsync.go)
+                                      |  dynamic informer factory (client-go)
+                                      v
+                          internal/pipeline.New(...)  <-- rebuilt every run/resync
+                                      |
+                    +-----------------+------------------+
+                    | Global-resource  | Local-resource    | StartInformers
+                    | discovery stage  | discovery stage   | stage
+                    +-----------------+------------------+
+                                      |
+                                      v
+                          internal/output.Writer  (broker | file | composite)
+                                      |            with internal/output dedup
+                                      v
+                     NATS broker (Meshery Server consumes it) or snapshot file
+```
+
+## Entry Point and Handler
+
+- `main.go` parses flags (`-output`, `-outputFile`, `-outputNamespaces`, `-outputResources`, `-stopAfter`) and calls `pkg/lib/meshsync.Run(...)`.
+- `meshsync.Handler` (`meshsync/meshsync.go`) holds the config, logger, broker handle, dynamic informer factory, kube client, channel pool, output writer, and output-filtration config. `meshsync.New(...)` wires them together and derives the cluster ID via `pkg/utils.GetClusterID`.
+- `GetDynamicInformer` builds a `dynamicinformer.DynamicSharedInformerFactory` filtered by a label selector derived from the config's informer blacklist.
+
+## Discovery Pipeline (`internal/pipeline`)
+
+- Built on `github.com/myntra/pipeline`. `pipeline.New(...)` constructs **fresh stages on every call** - it runs once at startup and again on every resync, so stages/steps must never be cached in package-level state (a shared stage would retain a shut-down informer factory and a closed stop channel from a prior run).
+- Three stages, run in order: **global-resource discovery**, **local-resource discovery** (both register one informer step per configured resource kind, skipping any kind excluded by `outputFiltration.ResourceSet`), then **StartInformers** (starts every registered informer against the given stop channel).
+- `internal/pipeline/step.go` defines the per-resource-kind informer registration step; `internal/pipeline/handlers.go` are the Add/Update/Delete event callbacks that convert an informer event into a `model.KubernetesResource` and hand it to the output writer.
+
+## Config (`internal/config`)
+
+- `config.go` / `default_config.go` / `crd_config.go` define the discoverable resource set (global vs. local/namespaced), whitelist/blacklist, and pluralization (`pluralise.go`) needed to map a Kind to its API resource.
+- `OutputFiltrationContainer` / `OutputResourceSet` (referenced from `meshsync.Handler`) carry the `-outputNamespaces` / `-outputResources` CLI restrictions through to the pipeline and output writer.
+
+## Output (`internal/output`)
+
+- `output.Writer` is the single interface consumed by the pipeline: `Write(obj model.KubernetesResource, evtype broker.EventType, config config.PipelineConfig) error`.
+- Implementations: `broker.go` (publishes to the MeshKit `broker.Handler`, i.e. NATS), `file.go` (writes a cluster snapshot via `internal/file`), `composite.go` (fans out to multiple writers - used when both broker and file output are needed).
+- `inmemory_deduplicator*.go` suppresses redundant republishes of unchanged resources; `processor.go` is the shared write-path plumbing.
+
+## Model (`pkg/model`)
+
+- `model.KubernetesResource` (plus `KubernetesResourceObjectMeta`, `KubernetesResourceSpec`, `KubernetesResourceStatus`, `KubernetesKeyValue`) is MeshSync's canonical wire/DB shape - a local Go/GORM struct, not generated from `github.com/meshery/schemas`. See [naming conventions](naming-conventions.md) for the casing implications.
+- `model_converter.go` / `preprocessor.go` convert a raw `unstructured.Unstructured` informer object into this model; `exec.go` / `log.go` / `process.go` handle exec-stream and log-stream requests routed in over the broker (see `meshsync/exec.go`, `meshsync/logstream.go`).
+
+## Channels (`internal/channels`)
+
+- `channel.go` / `generic.go` / `system.go` / `broker.go` define small typed channels (e.g. `StructChannel`) used for coordination (stop signals, broker request/response) between the handler and the pipeline - not a general pub/sub system.
+
+## Deployment Topology
+
+- Meshery Operator's `MeshSync` controller (`meshery/meshery-operator`, `pkg/meshsync/meshsync.go`) renders this binary as a `Deployment` and injects `BROKER_URL` pointing at the Broker's derived NATS endpoint. See that repo's architecture doc for the reconcile side.
+- Meshery Server subscribes to the NATS subjects MeshSync publishes on and persists/serves the resulting resource state; the `pkg/model.KubernetesResource` shape is the de facto contract between the two.
+- Coordinate CLI flag, config-schema, or model changes with both `meshery-operator` and `meshery` (server) - this repo does not own the full contract in isolation.
+
+## Further Reading
+
+- [design-spec: MeshSync infrastructure synchronization](../design-spec_meshsync-infrastructure-synchronization.md) - discovery concepts, tiered discovery, composite prints, user stories
+- [design-spec: embedded MeshSync](../design-spec_embedded-meshsync.md) - proposal for running MeshSync in-process inside Meshery Server

--- a/docs/agent-instructions/errors.md
+++ b/docs/agent-instructions/errors.md
@@ -1,0 +1,29 @@
+# Errors
+
+MeshSync uses MeshKit's structured error framework exclusively - never `fmt.Errorf`, std-lib `errors.New("...")`, or `pkg/errors`.
+
+## Convention
+
+- One exported code constant per error, matching `^Err[A-Z].+Code$` (e.g. `ErrGetObjectCode = "1004"`), plus one constructor:
+
+  ```go
+  func ErrGetObject(err error) error {
+      return errors.New(
+          ErrGetObjectCode, errors.Alert,
+          []string{"Error getting config object"},
+          []string{err.Error()},
+          []string{"Config doesnt exist"},
+          []string{"Check application config is configured correct or restart the server"},
+      )
+  }
+  ```
+
+- Codes are unique across the whole component, not just the package. Current registries: `meshsync/error.go` (1004-1013), `internal/pipeline/error.go`, `internal/config/error.go`.
+- Keep the short-description/probable-cause/remediation string literals as literals (the errorutil tool extracts them for the generated reference); the dynamic cause (`err.Error()`) goes only in the long description slot.
+
+## The `errorutil` Workflow
+
+- `helpers/component_info.json` tracks `next_error_code` for this component (`"name": "meshsync", "type": "controller"`) - allocate the next code from there when adding an error.
+- `.github/workflows/error-codes-updater.yml` runs on every push to `master` that touches `**.go`: it executes `go run github.com/meshery/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers`, which normalizes placeholder codes, bumps `next_error_code`, and writes `helpers/errorutil_errors_export.json` and related analysis artifacts, self-committing the result to `master`.
+- A second step in the same workflow pushes `helpers/errorutil_errors_export.json` into `meshery/meshery`'s `docs/_data/errorref/meshsync_errors_export.json` - this is the source of the MeshSync error-code reference on docs.meshery.io. Do not hand-edit that file in either repo.
+- Because the utility self-commits, do not hand-allocate or hand-renumber a code in a PR if you can instead push a placeholder and let the workflow assign it on merge; if you must allocate locally (e.g. to write a test against a specific code), expect the workflow to potentially renumber it after merge.

--- a/docs/agent-instructions/naming-conventions.md
+++ b/docs/agent-instructions/naming-conventions.md
@@ -1,0 +1,22 @@
+# Identifier Naming Conventions
+
+## The Ecosystem Contract
+
+**Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.**
+
+- Authoritative source: `meshery/schemas/AGENTS.md § Casing rules at a glance`
+- Reader-friendly directory: <https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>
+- The contract is not optional ecosystem-wide; deviations in schema-driven repos block PRs via the schemas consumer-audit CI gate.
+- `Id` (camelCase), never `ID`, in URL params, JSON tags, and TypeScript properties.
+
+## MeshSync's Divergence
+
+Unlike `meshery-cloud` (fully schema-driven), MeshSync's canonical model - `pkg/model.KubernetesResource` and its siblings (`KubernetesResourceObjectMeta`, `KubernetesResourceSpec`, `KubernetesResourceStatus`, `KubernetesKeyValue`) - is a **local Go/GORM struct**, not generated from `github.com/meshery/schemas`. It predates the ecosystem-wide schemas migration and has never been brought into it.
+
+The model already **mixes casing**: most JSON tags are camelCase (`apiVersion`, `resourceVersion`, `generateName`), but several are snake_case (`cluster_id`, `unique_id`, `pattern_resource`, `component_metadata`) and a few are lowercase-run-together legacy forms. This is known, load-bearing technical debt - Meshery Server and other consumers depend on the exact wire shape today.
+
+**Rules:**
+
+- New fields added to any `pkg/model` struct MUST use camelCase JSON tags, per the ecosystem contract - do not add another snake_case field to match the existing bad examples.
+- Do NOT opportunistically recase an existing field (e.g. `cluster_id` -> `clusterId`) as a drive-by cleanup. That is a breaking wire change for every consumer of the NATS stream (Meshery Server) and any persisted snapshot files; it requires an explicit, coordinated migration (bump a version, update all consumers in the same change, or introduce a new field alongside the old one with a deprecation path) - not a silent rename.
+- If a future change migrates `pkg/model` into `github.com/meshery/schemas` (bringing MeshSync fully into the schema-driven pattern used by `meshery-cloud`), that migration is the point to resolve the mixed casing deliberately, and it must run `cd ../schemas && make validate-schemas && make consumer-audit` and follow `schemas/AGENTS.md`'s Dual-Schema Pattern.

--- a/docs/agent-instructions/testing.md
+++ b/docs/agent-instructions/testing.md
@@ -1,0 +1,28 @@
+# Testing
+
+MeshSync has three tiers: unit tests, integration tests against a real kind cluster, and runtime verification of a running agent. Prefer the narrowest tier that actually exercises the changed code path.
+
+## Unit Tests
+
+- `make test` - runs `lint-run` first, then `go test -failfast --short ./... -race`.
+- `make lint-run` - `golangci-lint run ./...` on its own.
+- Single package: `go test ./internal/pipeline/... -race`
+- Single test: `go test ./internal/pipeline/... -run TestName -count=1`
+- `make coverage-report` - `go test -v ./... -coverprofile cover.out` then renders `cover.html`.
+- `make mod-tidy` - `go mod tidy`; run after any dependency change.
+
+## Integration Tests
+
+- `make integration-tests` runs the full cycle: `integration-tests-check-dependencies` (docker, kind, kubectl present) -> `integration-tests-setup` (`integration-tests/infrastructure/setup.sh setup` - NATS via docker-compose plus a kind cluster) -> `integration-tests-run` (builds the binary, then `RUN_INTEGRATION_TESTS=true MESHSYNC_BINARY_PATH=<abs path> SAVE_MESHSYNC_OUTPUT=true go test -v -count=1 -run Integration ./integration-tests`) -> `integration-tests-cleanup` (tears down docker-compose and the kind cluster).
+- Test files live directly under `integration-tests/` (not a nested Go package per scenario): binary-mode broker and file-output scenarios, library-mode custom-broker scenarios, and manifest-unmarshaling cases. Add a new case to the existing scenario file for its mode rather than creating a new top-level test file.
+- Run `integration-tests-setup` and `integration-tests-cleanup` in pairs - a leaked kind cluster or docker-compose stack from a prior failed run will make the next `integration-tests-run` misbehave; when in doubt, run `integration-tests-cleanup` before `integration-tests-setup`.
+
+## Runtime Verification
+
+Tests prove behavior in isolation; they do not prove the discovery pipeline actually fires correctly against a live cluster (informer resync, filtering, backoff/reconnect). For that, use the `verifier-meshsync` skill (`.claude/skills/verifier-meshsync/`), which scripts standing up an isolated local cluster, running the built binary in file mode with debug logging, and reading the evidence out of the log and output file. Reach for it whenever a change touches discovery, filtering, or config, or whenever `/verify` runs on this repo.
+
+## CI
+
+- `.github/workflows/ci.yml` - lint + unit tests on PRs.
+- `.github/workflows/integration-tests-ci.yml` - the integration-test cycle.
+- `.github/workflows/error-codes-updater.yml` - runs on push to `master` for `**.go` changes; see [errors](errors.md).


### PR DESCRIPTION
## Summary

MeshSync had no AGENTS.md or CLAUDE.md. This adds one, following the same progressive-disclosure refactor and shared engineering directives already applied across meshery-extensions, meshery-cloud, meshkit, meshery-operator, and schemas:

- `AGENTS.md` (48 lines): one-paragraph description, commands, four critical rules, the ecosystem-wide identifier-naming contract summary, a "Required on Every PR" block, and links to detail docs.
- `CLAUDE.md`: symlink to `AGENTS.md`.
- `docs/agent-instructions/architecture.md`: discovery pipeline, output/dedup, channels, config, deployment topology (MeshSync is deployed by meshery-operator's MeshSync controller and consumed by Meshery Server over NATS).
- `docs/agent-instructions/errors.md`: the MeshKit structured-error convention and the `error-codes-updater.yml` / errorutil workflow, including that it self-commits `helpers/errorutil_errors_export.json` into `meshery/meshery`'s docs data (the source of the docs.meshery.io error-code reference).
- `docs/agent-instructions/naming-conventions.md`: the ecosystem identifier-naming contract, plus an honest statement of MeshSync's actual divergence.
- `docs/agent-instructions/testing.md`: unit, integration, and runtime-verification (the existing `verifier-meshsync` skill) commands.

## A note on divergence (by design, not an oversight)

Other repos in this alignment pass (meshery-cloud, meshkit, meshery-operator) all point their "Required on Every PR" schema-aware bullet at an unconditional `cd ../schemas && make validate-schemas && make consumer-audit`. MeshSync's canonical wire model, `pkg/model.KubernetesResource`, is **not** sourced from `github.com/meshery/schemas` - it's a local Go/GORM struct that predates that migration and already mixes camelCase and snake_case JSON tags (e.g. `apiVersion` next to `cluster_id`). Rather than document a check that doesn't currently apply, `naming-conventions.md` states this plainly and conditions the schemas-validator requirement on an actual migration of this model into schemas, per the user's original instruction to diverge where appropriate rather than force uniform wording that would misrepresent the repo.

## Flagged out-of-scope (not fixed in this PR)

While researching this repo's existing Claude Code automation to document it accurately, I found `.claude/hooks/guard-local-models.sh`, `.claude/hooks/meshkit-errors.sh`, `.claude/hookify.meshkit-errors.local.md`, and `.claude/hooks/session-start.sh` all appear to have been copied verbatim from `meshery-cloud` without adaptation:

- They reference `server/**/*.go` and `server/models/**`, paths that do not exist in this repo (MeshSync's Go tree is `meshsync/`, `internal/`, `pkg/`).
- Their user-facing messages say "meshery-cloud" and cite "CLAUDE.md Critical Rule 1" and `make error`, none of which apply here.
- `guard-local-models.sh`'s entire premise (schema-driven `server/models`, blocking new local wire/DB structs) doesn't hold for MeshSync, whose model is legitimately local (see naming-conventions.md above) - so it's not just mis-pathed, its premise is wrong for this repo.
- `session-start.sh` opens by asserting "meshery-cloud is schema-driven" and provisions sibling repos on that basis.

Net effect: none of these hooks fire in this repo today (their path globs never match), so they are silently inert rather than actively wrong, but they are misleading if read as documentation of this repo's actual conventions. I did not fix them here to keep this PR to its stated scope (adding AGENTS.md); I'm flagging a follow-up task for it separately.

## Verification

- All relative markdown links in changed files resolve.
- Zero em-dash characters in any changed file.
- 15/15 distinctive source strings (function names, env vars, error codes, file paths) confirmed present in the new tree.
- `git log -1` shows `Signed-off-by`.