### PR TITLE
[MeshSync] Drop managedFields from payload; add opt-in Secret redaction

### DIFF
--- a/pkg/model/model_converter.go
+++ b/pkg/model/model_converter.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/buger/jsonparser"
 	"github.com/google/uuid"
@@ -11,6 +13,59 @@ import (
 	"github.com/meshery/meshkit/orchestration"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+// redactSecretsEnvKey is the environment variable that opts MeshSync into
+// redacting Kubernetes Secret contents before they are published over the
+// broker. It is OFF by default to preserve the existing cross-repo contract:
+// Meshery Server may consume Secret data (data/stringData/binaryData) that is
+// shipped over the broker, so changing the default could break downstream
+// behavior. When set to a truthy value ("true"/"1"), Secret values are replaced
+// with redactedSecretPlaceholder while the keys are preserved, so operators can
+// still see which Secret keys exist without the plaintext/base64 payloads
+// leaving the cluster.
+const redactSecretsEnvKey = "MESHSYNC_REDACT_SECRETS"
+
+// redactedSecretPlaceholder replaces Secret values when redaction is enabled.
+const redactedSecretPlaceholder = "[REDACTED]"
+
+// secretKind is the Kubernetes Kind for which Secret redaction applies.
+const secretKind = "Secret"
+
+// redactSecretsEnabled reports whether Secret redaction has been opted into via
+// the MESHSYNC_REDACT_SECRETS environment variable. It mirrors the truthy
+// parsing used elsewhere in MeshSync (see DEBUG handling in main.go).
+func redactSecretsEnabled() bool {
+	v := os.Getenv(redactSecretsEnvKey)
+	return strings.ToLower(v) == "true" || v == "1"
+}
+
+// redactSecretData takes the raw JSON object captured from a Secret's
+// data/stringData/binaryData field (e.g. {"password":"cGFzcw=="}) and returns
+// an equivalent JSON object with every value replaced by
+// redactedSecretPlaceholder while preserving the keys. If the input is not a
+// JSON object (empty, malformed, or unexpected shape), it is returned
+// unchanged so redaction never corrupts or drops data it does not understand.
+func redactSecretData(raw string) string {
+	if raw == "" {
+		return raw
+	}
+
+	var kv map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &kv); err != nil {
+		return raw
+	}
+
+	redacted := make(map[string]string, len(kv))
+	for key := range kv {
+		redacted[key] = redactedSecretPlaceholder
+	}
+
+	out, err := json.Marshal(redacted)
+	if err != nil {
+		return raw
+	}
+	return string(out)
+}
 
 // TODO fix cyclop error
 // Error: pkg/model/model_converter.go:16:1: calculated cyclomatic complexity for function ParseList is 13, max is 10 (cyclop)
@@ -59,9 +114,13 @@ func ParseList(
 		result.KubernetesResourceMeta.Finalizers = string(finalizers)
 	}
 
-	if managedFields, _, _, err := jsonparser.Get(data, "metadata", "managedFields"); err == nil {
-		result.KubernetesResourceMeta.ManagedFields = string(managedFields)
-	}
+	// metadata.managedFields is intentionally NOT captured. It is large,
+	// high-churn server-side-apply bookkeeping that is never persisted
+	// (the ManagedFields struct field is gorm:"-"), yet it was previously
+	// serialized and published over the broker on every event, inflating
+	// every message. The ManagedFields struct field is left in place
+	// (unpopulated) because KubernetesResourceObjectMeta is a shared contract
+	// consumed by meshery-server; removing the field would be a breaking change.
 
 	if ownerReferences, _, _, err := jsonparser.Get(data, "metadata", "ownerReferences"); err == nil {
 		result.KubernetesResourceMeta.OwnerReferences = string(ownerReferences)
@@ -79,16 +138,34 @@ func ParseList(
 		result.Immutable = string(immutable)
 	}
 
+	// Secret contents (data/stringData/binaryData) are captured and shipped
+	// over the broker. Meshery Server may consume this data, so the default
+	// behavior is unchanged (values pass through as-is). When an operator opts
+	// in via MESHSYNC_REDACT_SECRETS, Secret values are redacted here while the
+	// keys are preserved, keeping plaintext/base64 secrets from leaving the
+	// cluster. Redaction applies to Secret resources only; ConfigMap data is
+	// left untouched.
+	redactSecrets := redactSecretsEnabled() && result.Kind == secretKind
+
 	if objData, _, _, err := jsonparser.Get(data, "data"); err == nil {
 		result.Data = string(objData)
+		if redactSecrets {
+			result.Data = redactSecretData(result.Data)
+		}
 	}
 
 	if binaryData, _, _, err := jsonparser.Get(data, "binaryData"); err == nil {
 		result.BinaryData = string(binaryData)
+		if redactSecrets {
+			result.BinaryData = redactSecretData(result.BinaryData)
+		}
 	}
 
 	if stringData, _, _, err := jsonparser.Get(data, "stringData"); err == nil {
 		result.StringData = string(stringData)
+		if redactSecrets {
+			result.StringData = redactSecretData(result.StringData)
+		}
 	}
 
 	if objType, _, _, err := jsonparser.Get(data, "type"); err == nil {

--- a/pkg/model/model_converter.go
+++ b/pkg/model/model_converter.go
@@ -45,14 +45,14 @@ func redactSecretsEnabled() bool {
 // redactedSecretPlaceholder while preserving the keys. If the input is not a
 // JSON object (empty, malformed, or unexpected shape), it is returned
 // unchanged so redaction never corrupts or drops data it does not understand.
-func redactSecretData(raw string) string {
-	if raw == "" {
-		return raw
+func redactSecretData(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
 	}
 
 	var kv map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(raw), &kv); err != nil {
-		return raw
+	if err := json.Unmarshal(raw, &kv); err != nil {
+		return string(raw)
 	}
 
 	redacted := make(map[string]string, len(kv))
@@ -62,7 +62,7 @@ func redactSecretData(raw string) string {
 
 	out, err := json.Marshal(redacted)
 	if err != nil {
-		return raw
+		return string(raw)
 	}
 	return string(out)
 }
@@ -145,26 +145,32 @@ func ParseList(
 	// keys are preserved, keeping plaintext/base64 secrets from leaving the
 	// cluster. Redaction applies to Secret resources only; ConfigMap data is
 	// left untouched.
-	redactSecrets := redactSecretsEnabled() && result.Kind == secretKind
+	// result.Kind is checked first so redactSecretsEnabled() (which reads the
+	// environment) is only evaluated for Secret resources, not on the hot path
+	// for every non-Secret resource.
+	redactSecrets := result.Kind == secretKind && redactSecretsEnabled()
 
 	if objData, _, _, err := jsonparser.Get(data, "data"); err == nil {
-		result.Data = string(objData)
 		if redactSecrets {
-			result.Data = redactSecretData(result.Data)
+			result.Data = redactSecretData(objData)
+		} else {
+			result.Data = string(objData)
 		}
 	}
 
 	if binaryData, _, _, err := jsonparser.Get(data, "binaryData"); err == nil {
-		result.BinaryData = string(binaryData)
 		if redactSecrets {
-			result.BinaryData = redactSecretData(result.BinaryData)
+			result.BinaryData = redactSecretData(binaryData)
+		} else {
+			result.BinaryData = string(binaryData)
 		}
 	}
 
 	if stringData, _, _, err := jsonparser.Get(data, "stringData"); err == nil {
-		result.StringData = string(stringData)
 		if redactSecrets {
-			result.StringData = redactSecretData(result.StringData)
+			result.StringData = redactSecretData(stringData)
+		} else {
+			result.StringData = string(stringData)
 		}
 	}
 

--- a/pkg/model/model_converter_test.go
+++ b/pkg/model/model_converter_test.go
@@ -176,7 +176,7 @@ func TestRedactSecretsEnabled(t *testing.T) {
 
 func TestRedactSecretData(t *testing.T) {
 	t.Run("redacts values preserving keys", func(t *testing.T) {
-		out := redactSecretData(`{"password":"cGFzcw==","username":"YWRtaW4="}`)
+		out := redactSecretData([]byte(`{"password":"cGFzcw==","username":"YWRtaW4="}`))
 		assertJSONEqual(t, out, map[string]string{
 			"password": redactedSecretPlaceholder,
 			"username": redactedSecretPlaceholder,
@@ -184,20 +184,20 @@ func TestRedactSecretData(t *testing.T) {
 	})
 
 	t.Run("empty input is returned unchanged", func(t *testing.T) {
-		if out := redactSecretData(""); out != "" {
+		if out := redactSecretData(nil); out != "" {
 			t.Errorf("expected empty string, got %q", out)
 		}
 	})
 
 	t.Run("malformed json is returned unchanged", func(t *testing.T) {
-		in := `{not-json`
-		if out := redactSecretData(in); out != in {
+		in := []byte(`{not-json`)
+		if out := redactSecretData(in); out != string(in) {
 			t.Errorf("expected input returned unchanged, got %q", out)
 		}
 	})
 
 	t.Run("empty object stays empty object", func(t *testing.T) {
-		if out := redactSecretData(`{}`); out != `{}` {
+		if out := redactSecretData([]byte(`{}`)); out != `{}` {
 			t.Errorf("expected {}, got %q", out)
 		}
 	})

--- a/pkg/model/model_converter_test.go
+++ b/pkg/model/model_converter_test.go
@@ -1,0 +1,223 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/meshery/meshkit/broker"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// newUnstructured builds an *unstructured.Unstructured from a nested map, the
+// same shape the informer delivers to ParseList.
+func newUnstructured(obj map[string]interface{}) unstructured.Unstructured {
+	return unstructured.Unstructured{Object: obj}
+}
+
+// TestParseList_ManagedFieldsNotCaptured is the regression test for the payload
+// bloat fix: metadata.managedFields must never be captured into the published
+// resource, even when the source object carries it.
+func TestParseList_ManagedFieldsNotCaptured(t *testing.T) {
+	obj := newUnstructured(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "cm",
+			"namespace": "default",
+			"managedFields": []interface{}{
+				map[string]interface{}{
+					"manager":   "kube-controller-manager",
+					"operation": "Update",
+					"fieldsV1": map[string]interface{}{
+						"f:data": map[string]interface{}{},
+					},
+				},
+			},
+		},
+	})
+
+	result := ParseList(obj, broker.Add, "cluster-1")
+
+	if result.KubernetesResourceMeta == nil {
+		t.Fatalf("expected metadata to be populated")
+	}
+	if result.KubernetesResourceMeta.ManagedFields != "" {
+		t.Errorf("expected ManagedFields to be empty, got %q", result.KubernetesResourceMeta.ManagedFields)
+	}
+}
+
+// TestParseList_SecretRedactionDisabledByDefault asserts the default (env var
+// unset) behavior is byte-for-byte unchanged: Secret data/stringData passes
+// through exactly as it appears in the source object.
+func TestParseList_SecretRedactionDisabledByDefault(t *testing.T) {
+	// Ensure the env var is unset for this test regardless of ambient state.
+	t.Setenv(redactSecretsEnvKey, "")
+
+	obj := newUnstructured(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      "db-creds",
+			"namespace": "default",
+		},
+		"type": "Opaque",
+		"data": map[string]interface{}{
+			"password": "cGFzc3dvcmQ=",
+			"username": "YWRtaW4=",
+		},
+		"stringData": map[string]interface{}{
+			"token": "plaintext-token",
+		},
+	})
+
+	result := ParseList(obj, broker.Add, "cluster-1")
+
+	if result.Data == "" {
+		t.Fatalf("expected Data to be populated")
+	}
+	assertJSONEqual(t, result.Data, map[string]string{
+		"password": "cGFzc3dvcmQ=",
+		"username": "YWRtaW4=",
+	})
+	assertJSONEqual(t, result.StringData, map[string]string{
+		"token": "plaintext-token",
+	})
+}
+
+// TestParseList_SecretRedactionEnabled asserts that when the opt-in env var is
+// set, Secret data/stringData/binaryData VALUES are redacted while the KEYS are
+// preserved.
+func TestParseList_SecretRedactionEnabled(t *testing.T) {
+	t.Setenv(redactSecretsEnvKey, "true")
+
+	obj := newUnstructured(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      "db-creds",
+			"namespace": "default",
+		},
+		"type": "Opaque",
+		"data": map[string]interface{}{
+			"password": "cGFzc3dvcmQ=",
+			"username": "YWRtaW4=",
+		},
+		"stringData": map[string]interface{}{
+			"token": "plaintext-token",
+		},
+		"binaryData": map[string]interface{}{
+			"cert": "YmluYXJ5",
+		},
+	})
+
+	result := ParseList(obj, broker.Add, "cluster-1")
+
+	assertJSONEqual(t, result.Data, map[string]string{
+		"password": redactedSecretPlaceholder,
+		"username": redactedSecretPlaceholder,
+	})
+	assertJSONEqual(t, result.StringData, map[string]string{
+		"token": redactedSecretPlaceholder,
+	})
+	assertJSONEqual(t, result.BinaryData, map[string]string{
+		"cert": redactedSecretPlaceholder,
+	})
+}
+
+// TestParseList_RedactionEnabledLeavesConfigMapUntouched asserts that redaction
+// is scoped to Secret resources only: a ConfigMap's data is passed through even
+// when redaction is enabled.
+func TestParseList_RedactionEnabledLeavesConfigMapUntouched(t *testing.T) {
+	t.Setenv(redactSecretsEnvKey, "true")
+
+	obj := newUnstructured(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "app-config",
+			"namespace": "default",
+		},
+		"data": map[string]interface{}{
+			"log_level": "debug",
+		},
+	})
+
+	result := ParseList(obj, broker.Add, "cluster-1")
+
+	assertJSONEqual(t, result.Data, map[string]string{
+		"log_level": "debug",
+	})
+}
+
+func TestRedactSecretsEnabled(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"", false},
+		{"false", false},
+		{"0", false},
+		{"no", false},
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"1", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.value, func(t *testing.T) {
+			t.Setenv(redactSecretsEnvKey, tc.value)
+			if got := redactSecretsEnabled(); got != tc.want {
+				t.Errorf("redactSecretsEnabled() with %q = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRedactSecretData(t *testing.T) {
+	t.Run("redacts values preserving keys", func(t *testing.T) {
+		out := redactSecretData(`{"password":"cGFzcw==","username":"YWRtaW4="}`)
+		assertJSONEqual(t, out, map[string]string{
+			"password": redactedSecretPlaceholder,
+			"username": redactedSecretPlaceholder,
+		})
+	})
+
+	t.Run("empty input is returned unchanged", func(t *testing.T) {
+		if out := redactSecretData(""); out != "" {
+			t.Errorf("expected empty string, got %q", out)
+		}
+	})
+
+	t.Run("malformed json is returned unchanged", func(t *testing.T) {
+		in := `{not-json`
+		if out := redactSecretData(in); out != in {
+			t.Errorf("expected input returned unchanged, got %q", out)
+		}
+	})
+
+	t.Run("empty object stays empty object", func(t *testing.T) {
+		if out := redactSecretData(`{}`); out != `{}` {
+			t.Errorf("expected {}, got %q", out)
+		}
+	})
+}
+
+// assertJSONEqual compares a JSON string against an expected key/value map,
+// tolerating key-ordering differences that json.Marshal does not guarantee.
+func assertJSONEqual(t *testing.T, got string, want map[string]string) {
+	t.Helper()
+
+	var gotMap map[string]string
+	if err := json.Unmarshal([]byte(got), &gotMap); err != nil {
+		t.Fatalf("failed to unmarshal %q: %v", got, err)
+	}
+	if len(gotMap) != len(want) {
+		t.Fatalf("map length mismatch: got %v, want %v", gotMap, want)
+	}
+	for k, v := range want {
+		if gotMap[k] != v {
+			t.Errorf("key %q: got %q, want %q", k, gotMap[k], v)
+		}
+	}
+}


### PR DESCRIPTION
**Description**

Reduce MeshSync's published payload size and add opt-in Secret redaction (`pkg/model/model_converter.go`).

- **Stop publishing `managedFields`:** `ParseList` captured `metadata.managedFields` - large, high-churn server-side-apply bookkeeping - onto every resource. The struct field is already `gorm:"-"` (never persisted), yet it was serialized over the broker on every event, inflating every message. The capture is removed; the struct field stays in place (unpopulated) because `KubernetesResourceObjectMeta` is a shared contract with meshery-server, and `omitempty` now drops it from the wire.
- **Opt-in Secret redaction (default OFF):** `MESHSYNC_REDACT_SECRETS`, when set, redacts `Secret` `data`/`stringData`/`binaryData` values while preserving keys (ConfigMaps untouched). Default behavior is byte-for-byte identical to today, so the cross-repo contract with meshery-server (which may consume Secret data) is not broken.

**Notes for Reviewers**

`go build ./...` and `go test ./...` pass. Unit tests cover managedFields removal, redaction-off pass-through, redaction-on for each field, and Secret-only scoping. Redaction is deliberately opt-in so this PR is non-breaking; if meshery-server should stop receiving Secret contents by default, that is a coordinated follow-up.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
