### PR TITLE
[Docs] Blueprint cleanup: strip agent preambles, fix prose typo (follow-up to #576)

### DIFF
--- a/docs/design/fd1-tiered-configurable-discovery.md
+++ b/docs/design/fd1-tiered-configurable-discovery.md
@@ -1,7 +1,3 @@
-I have a complete picture now across all six repos. I have enough grounding to produce the full blueprint.
-
----
-
 # IMPLEMENTATION BLUEPRINT: Tiered & Configurable Discovery
 
 ## 1. Goal & Gap

--- a/docs/design/fd2-rate-limited-work-queue.md
+++ b/docs/design/fd2-rate-limited-work-queue.md
@@ -1,7 +1,3 @@
-I have full grounding now. Let me construct the blueprint.
-
----
-
 # Implementation Blueprint: Rate-Limited Work Queue + Converter (Backpressure)
 
 ## 1. Goal & Gap

--- a/docs/design/fd3-composite-fingerprints.md
+++ b/docs/design/fd3-composite-fingerprints.md
@@ -1,9 +1,3 @@
-This is exactly the "sibling / match-labels" pattern already implemented for design-authoring, operating on `component.Component`'s configuration fields via `sel.Match.Refs` JSON-path lookups against `design.Components` (a slice). This is the precise algorithmic shape (bucket-by-shared-field-value, `sibling` kind, N.log(N) grouping) I should mirror for the runtime-inventory case, confirming `sibling`/`matchlabels` as the taxonomy for the peer/grouping relationship (as opposed to `hierarchical`/`inventory`/`parent` for a Deployment->Pod-style parent-child edge). This gives me the complete taxonomy mapping needed for the schema section: `sibling.matchlabels` for same-app grouping, `hierarchical.inventory.parent` reused for owner-reference chains within the app.
-
-I now have full grounding across all four repos. Here is the blueprint.
-
----
-
 # Blueprint: Composite Fingerprints Spanning Multiple Entities
 
 ## 1. Goal & Gap

--- a/docs/design/fd4-jetstream-durable-delivery.md
+++ b/docs/design/fd4-jetstream-durable-delivery.md
@@ -1,7 +1,3 @@
-I have complete grounding across all five repositories. I'm now ready to author the full blueprint.
-
----
-
 # Blueprint: Durable Delivery via NATS JetStream
 
 ## 1. Goal & Gap

--- a/docs/design/fd5-periodic-reconciliation.md
+++ b/docs/design/fd5-periodic-reconciliation.md
@@ -1,7 +1,3 @@
-That's just generic boilerplate, not prescriptive. I now have full grounding. Let me produce the blueprint.
-
----
-
 # Blueprint: Periodic Reconciliation / Resync for MeshSync
 
 ## 1. Goal and Gap
@@ -133,7 +129,7 @@ Implemented as the third branch above: for each reconciled GVR, take the key set
 
 - **CRD is the schema of record** for this field (see §2/§4). `spec.reconcile-interval` (`metav1.Duration`, both `v1alpha1` and `v1alpha2`), `omitempty`, default absent = disabled.
 - **Versioning**: added to both existing API versions identically in the same PR — no new CRD API version is needed, and doing otherwise would violate the `conversion.go` round-trip invariant.
-- **Back-compat**: an existing `MeshSync` CR without `reconcile-interval` set unmarshal to the Go zero value (`metav1.Duration{}`, i.e. `0`), which the Operator's `applyReconcileInterval` treats as "no-op, omit env var," and MeshSync's own resolution treats as "disabled" — fully backward compatible, no migration needed for existing CRs.
+- **Back-compat**: an existing `MeshSync` CR without `reconcile-interval` set unmarshals to the Go zero value (`metav1.Duration{}`, i.e. `0`), which the Operator's `applyReconcileInterval` treats as "no-op, omit env var," and MeshSync's own resolution treats as "disabled" — fully backward compatible, no migration needed for existing CRs.
 - **MeshSync-side config**: new `ReconcileIntervalKey` in `internal/config/config.go`, populated via `RECONCILE_INTERVAL` env (set by Operator) or `-reconcileInterval` CLI flag (dev/file-mode), resolved once at `pkg/lib/meshsync.Run` startup — no runtime CRD re-poll for interval changes; a change to `spec.reconcile-interval` takes effect on the next MeshSync pod restart (Operator's SSA + rollout), consistent with how `spec.version`/`spec.size` already work (Deployment update → rollout → new pod picks up new env). This avoids adding a *second* live-reload mechanism (the existing CRD watch/`WatchCRDs` path is scoped to the resource whitelist/blacklist, not this scalar) — flagged as a deliberate simplification in §11 rather than a gap, since resource-set changes already require the same rollout-based propagation for `watch-list` today when driven by direct CR edit (only informer-level GVR set changes via the CRD-watch path get live-applied without restart, and that's a different, existing mechanism this feature does not need to replicate).
 
 ## 6. Sequencing and Feature-Flagging

--- a/docs/design/fd6-non-kubernetes-discovery.md
+++ b/docs/design/fd6-non-kubernetes-discovery.md
@@ -1,9 +1,3 @@
-I have everything I need. No pre-existing `Discoverer`/`Platform` abstraction anywhere. `component_info.json`'s `next_error_code: 1015` is already claimed by `ErrWriteOutputCode` in `internal/pipeline/error.go` (the file's local numbering has drifted ahead of the tracked `next_error_code` - I'll flag this as a pre-existing inconsistency worth noting, not something to fix as part of this design task, per the "flag, don't silently step over" instruction, but only as an aside since it's an unrelated latent bookkeeping gap, not something this feature touches directly).
-
-I now have full grounding across all five repos. Here is the blueprint.
-
----
-
 # IMPLEMENTATION BLUEPRINT: Non-Kubernetes / Multi-Platform Discovery for MeshSync
 
 ## 1. Goal & Gap


### PR DESCRIPTION
**Description**

Follow-up to the merged #576, addressing the review feedback on the Part A blueprints:

- Removed the conversational agent intro lines and the leading horizontal rule from each of the six blueprints.
- Fixed a prose typo: "unmarshal" -> "unmarshals" in the reconciliation blueprint.

Kept intentionally (these are verbatim code identifiers from the codebase, not typos - correcting them would make the citations un-greppable): `DefautOptions` (`pkg/lib/meshsync/options.go`), `subsribeToStoreUpdates` (meshery/server `models/meshsync_events.go`), `meshsynDataHandlersNatsBroker` (meshery/server `models/meshery_controllers.go`).

**Notes for Reviewers**

Docs-only. #576 merged before this review feedback could be folded in, hence the follow-up.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
