### PR TITLE
[MeshSync] Fix data race on informer stores map

### DIFF
--- a/meshsync/discovery.go
+++ b/meshsync/discovery.go
@@ -45,5 +45,28 @@ func (h *Handler) startDiscovery(pipelineCh chan struct{}) {
 		return
 	}
 
+	h.replaceStores(data)
+}
+
+// replaceStores swaps in the per-GVR informer store set produced by a discovery
+// run. stores is read concurrently by handleInformerStoreRequest, so the swap is
+// guarded by storesMu.
+func (h *Handler) replaceStores(data map[string]cache.Store) {
+	h.storesMu.Lock()
+	defer h.storesMu.Unlock()
 	h.stores = data
+}
+
+// snapshotStores returns the current per-GVR informer stores. storesMu is held
+// only while copying the map values, never across the caller's subsequent
+// store reads, so a store List() never blocks the discovery goroutine's next
+// replaceStores.
+func (h *Handler) snapshotStores() []cache.Store {
+	h.storesMu.RLock()
+	defer h.storesMu.RUnlock()
+	stores := make([]cache.Store, 0, len(h.stores))
+	for _, s := range h.stores {
+		stores = append(stores, s)
+	}
+	return stores
 }

--- a/meshsync/handlers.go
+++ b/meshsync/handlers.go
@@ -293,7 +293,7 @@ func (h *Handler) publishMeshSyncMeta() {
 
 func (h *Handler) listStoreObjects() []model.KubernetesResource {
 	objects := make([]interface{}, 0)
-	for _, v := range h.stores {
+	for _, v := range h.snapshotStores() {
 		objects = append(objects, v.List()...)
 	}
 	parsedObjects := make([]model.KubernetesResource, 0)

--- a/meshsync/meshsync.go
+++ b/meshsync/meshsync.go
@@ -30,10 +30,15 @@ type Handler struct {
 	// channelPool holds the fixed system channels (Stop/OS/ReSync) and is
 	// read-only after construction. Dynamic exec/log-stream sessions live in
 	// sessions (guarded by sessionsMu), not here, so the two never race.
-	channelPool      map[string]channels.GenericChannel
-	sessions         map[string]channels.StructChannel
-	sessionsMu       sync.Mutex
+	channelPool map[string]channels.GenericChannel
+	sessions    map[string]channels.StructChannel
+	sessionsMu  sync.Mutex
+	// stores holds the per-GVR informer store set from the latest discovery.
+	// startDiscovery replaces it wholesale on the discovery goroutine on every
+	// (re)discovery while handleInformerStoreRequest reads it on the request
+	// listener goroutine; storesMu guards that concurrent field access.
 	stores           map[string]cache.Store
+	storesMu         sync.RWMutex
 	outputWriter     output.Writer
 	outputFiltration internalconfig.OutputFiltrationContainer
 }

--- a/meshsync/stores_test.go
+++ b/meshsync/stores_test.go
@@ -1,0 +1,67 @@
+package meshsync
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func newStoresHandler() *Handler {
+	return &Handler{stores: make(map[string]cache.Store)}
+}
+
+// TestStoresConcurrentAccess must pass under -race: the discovery goroutine
+// replaces the stores map wholesale on every (re)discovery while the request
+// listener goroutine snapshots it to answer informer-store requests. Without
+// storesMu that is an unsynchronized read/write of the map field.
+func TestStoresConcurrentAccess(t *testing.T) {
+	h := newStoresHandler()
+
+	const workers = 16
+	const iterations = 500
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if w%2 == 0 {
+					h.replaceStores(map[string]cache.Store{
+						fmt.Sprintf("gvr-%d", w): cache.NewStore(cache.MetaNamespaceKeyFunc),
+					})
+				} else {
+					for _, s := range h.snapshotStores() {
+						_ = s.List()
+					}
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+}
+
+// TestSnapshotStoresReturnsAllStores verifies snapshotStores returns every
+// current store so informer-store replies stay complete after the guard.
+func TestSnapshotStoresReturnsAllStores(t *testing.T) {
+	h := newStoresHandler()
+	h.replaceStores(map[string]cache.Store{
+		"a": cache.NewStore(cache.MetaNamespaceKeyFunc),
+		"b": cache.NewStore(cache.MetaNamespaceKeyFunc),
+		"c": cache.NewStore(cache.MetaNamespaceKeyFunc),
+	})
+	if got := len(h.snapshotStores()); got != 3 {
+		t.Fatalf("snapshotStores returned %d stores, want 3", got)
+	}
+}
+
+// TestSnapshotStoresNilMap confirms a Handler whose stores map was never
+// initialized (nil, as before the first discovery) snapshots to empty rather
+// than panicking.
+func TestSnapshotStoresNilMap(t *testing.T) {
+	h := &Handler{}
+	if got := len(h.snapshotStores()); got != 0 {
+		t.Fatalf("snapshotStores on a nil map returned %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## What's going on

`Handler.stores` — the per-GVR informer store set — gets replaced wholesale by `startDiscovery` on the discovery goroutine every time (re)discovery runs, and it's read on a different goroutine by `handleInformerStoreRequest` → `listStoreObjects` whenever Meshery Server asks for an `informer-store`. Those two run at the same time with nothing synchronizing them, so the field is read and written with no happens-before between them — a data race, and `go test -race` flags it. It's the same shape as the bug already fixed for the exec/log-stream `sessions` map.

## What I changed

I put an `RWMutex` (`storesMu`) around the `stores` field. The wholesale swap now goes through `replaceStores` under the write lock, and reads go through `snapshotStores`, which copies the current store values under the read lock and hands those back — so the lock is never held across `cache.Store.List()`. `listStoreObjects` iterates `snapshotStores()` instead of the raw map.

Nothing exported changes — no API, wire format, CRD, or config. Access is read-mostly, which is why `RWMutex`, and the set of objects returned is exactly what it was before.

## Testing

Added `meshsync/stores_test.go`. `TestStoresConcurrentAccess` runs 16 goroutines racing replace against snapshot; it passes under `-race`, and it reports the race if you remove the guard, so it actually catches the regression. There are also completeness and nil-map cases. `go test --short ./... -race` is green across all packages, and `go vet` / `gofmt` are clean.

## Why send it on its own

It's a prerequisite for the periodic-reconciliation work (`docs/design/fd5-periodic-reconciliation.md`), which adds a timer-driven reconcile loop that would be the second concurrent reader of `h.stores` alongside the informer-store path. I'm keeping it separate so that feature builds on a race-free store instead of bundling the fix into it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when discovery updates resource stores while requests are being handled.
  * Prevented potential concurrency issues and failures when retrieving stored resources, including when no stores are available.

* **Tests**
  * Added coverage for concurrent store updates, complete store snapshots, and empty-store scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
